### PR TITLE
Add update-claudemd skill and document missing skills

### DIFF
--- a/.claude/skills/update-claudemd/SKILL.md
+++ b/.claude/skills/update-claudemd/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: update-claudemd
+description: Review recent changes and update CLAUDE.md if needed
+---
+
+# Update CLAUDE.md
+
+Review recent git changes and update the project's CLAUDE.md file to reflect any significant changes to the codebase.
+
+## When to Update CLAUDE.md
+
+The CLAUDE.md file should be updated when changes affect:
+
+- **New modules/packages**: New directories or significant files added
+- **Public API changes**: New classes, functions, or parameters exposed
+- **Architecture changes**: New patterns, abstractions, or workflows
+- **Development commands**: New scripts, test commands, or setup steps
+- **Dependencies**: New required packages or tools
+- **Key examples**: New example files or significant example updates
+- **Testing patterns**: New test fixtures, helpers, or conventions
+- **Component additions**: New components in `happysimulator/components/`
+- **Distribution additions**: New distributions in `happysimulator/distributions/`
+
+## What NOT to Update
+
+Do not update CLAUDE.md for:
+- Bug fixes that don't change the API
+- Internal refactoring without API changes
+- Test additions that follow existing patterns
+- Documentation typo fixes
+- Minor parameter tweaks
+
+## Instructions
+
+1. **Examine recent changes** using git commands:
+   ```bash
+   # View recent commits (last 5-10)
+   git log --oneline -10
+
+   # View changes since last CLAUDE.md update
+   git log --oneline CLAUDE.md
+
+   # View what files changed recently
+   git diff --name-only HEAD~5
+
+   # View detailed diff for specific commits
+   git show <commit-hash> --stat
+   ```
+
+2. **Identify significant changes** by looking for:
+   - New files in `happysimulator/` (especially in `core/`, `components/`, `distributions/`)
+   - New files in `examples/`
+   - Changes to `__init__.py` files (public API changes)
+   - New test patterns in `tests/`
+   - New development scripts or commands
+
+3. **Read the current CLAUDE.md** to understand existing structure:
+   - Quick Reference table
+   - Reading Order for New Contributors
+   - Development Commands
+   - Core Abstractions
+   - Architecture
+   - Key Directories
+   - Testing Patterns
+   - Example Patterns
+   - Common Patterns
+   - Troubleshooting
+   - Code Style
+
+4. **Propose updates** by:
+   - Identifying which sections need changes
+   - Drafting the specific additions/modifications
+   - Explaining why each change is needed
+
+5. **Apply updates** to CLAUDE.md:
+   - Make minimal, targeted edits
+   - Maintain consistent style with existing content
+   - Preserve the existing structure
+   - Add new entries in appropriate sections
+   - **Update the timestamp** at the top of the file (the `> **Last Updated:** YYYY-MM-DD` line)
+
+6. **Verify updates** are correct and complete
+
+## Timestamp Format
+
+CLAUDE.md has a timestamp near the top in this format:
+
+```markdown
+> **Last Updated:** 2026-01-31
+```
+
+When making ANY updates to CLAUDE.md, update this date to the current date in `YYYY-MM-DD` format.
+
+## Example Output
+
+When running this skill, provide a summary like:
+
+```
+## Changes Analyzed
+- Commit abc123: Added CircuitBreaker component
+- Commit def456: New Pareto distribution
+
+## CLAUDE.md Updates Needed
+1. **Key Directories**: Add entry for `components/resilience/`
+2. **Common Patterns**: Add CircuitBreaker usage example
+3. **Core Abstractions**: Document Pareto distribution
+
+## Updates Applied
+- Added CircuitBreaker to components table
+- Added ParetoLatency to distributions list
+```
+
+## No Updates Needed
+
+If no significant changes warrant CLAUDE.md updates, report:
+
+```
+## Changes Analyzed
+- Commit abc123: Fixed typo in docstring
+- Commit def456: Added unit test for existing feature
+
+## CLAUDE.md Updates Needed
+None - recent changes are internal improvements that don't affect the documented API or patterns.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+> **Last Updated:** 2026-01-31
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ---
@@ -720,11 +722,15 @@ The following skills are available for use in this project:
 | `/commit` | Create a git commit with conventional message |
 | `/commit-push-pr` | Commit, push, and open a pull request |
 | `/code-review` | Review a pull request for issues and improvements |
+| `/gen-test` | Generate a pytest test following project conventions |
+| `/run-example` | Run a simulation example and analyze the output |
+| `/update-claudemd` | Review recent changes and update CLAUDE.md if needed |
 | `/claude-automation-recommender` | Analyze codebase and recommend Claude Code automations |
 
 ### Subagents (Internal)
 
 Claude Code uses specialized subagents internally:
+- **simulation-reviewer**: Specialized code reviewer for discrete-event simulation code
 - **code-simplifier**: Simplifies and refines code for clarity and maintainability
 - **Explore**: Fast codebase exploration and search
 - **Plan**: Implementation planning and architecture design


### PR DESCRIPTION
## Summary
- Add `/update-claudemd` skill that reviews recent git changes and updates CLAUDE.md when significant changes are detected
- Add last-updated timestamp to CLAUDE.md header
- Document previously missing skills (`/gen-test`, `/run-example`) in the skills table
- Document `simulation-reviewer` subagent

## Test plan
- [ ] Invoke `/update-claudemd` and verify it analyzes recent commits
- [ ] Verify the skill correctly identifies when CLAUDE.md updates are needed vs not needed
- [ ] Confirm timestamp format is correct (`YYYY-MM-DD`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)