### PR TITLE
Fix matplotlib warnings in tests

### DIFF
--- a/examples/gc_caused_collapse.py
+++ b/examples/gc_caused_collapse.py
@@ -745,7 +745,8 @@ def visualize_results(result: ComparisonResult, output_dir: Path) -> None:
     ax1.set_ylabel("GC Events")
     gc_dur_ms = with_r.server.gc_duration_s * 1000
     ax1.set_title(f"GC Pause ({gc_dur_ms:.0f}ms at t={with_r.server.gc_start_time_s:.0f}s)")
-    ax1.legend(loc="upper right")
+    if ax1.get_legend_handles_labels()[1]:
+        ax1.legend(loc="upper right")
     ax1.set_ylim(0, 1)
     ax1.set_yticks([])
     ax1.grid(True, alpha=0.3)
@@ -895,7 +896,8 @@ def visualize_results(result: ComparisonResult, output_dir: Path) -> None:
     ax3.set_xlabel("Time (s)")
     ax3.set_ylabel("Cumulative Timeouts")
     ax3.set_title("Cumulative Client Timeouts Over Time")
-    ax3.legend(loc="upper left")
+    if ax3.get_legend_handles_labels()[1]:
+        ax3.legend(loc="upper left")
     ax3.grid(True, alpha=0.3)
 
     # Plot 4: Summary Statistics Box

--- a/tests/integration/test_async_server_explained.py
+++ b/tests/integration/test_async_server_explained.py
@@ -547,7 +547,7 @@ class TestAsyncServerExplained:
         │ Completed: {async_server.stats.requests_completed}                    │
         │ Avg Latency: {async_avg:.0f}ms               │
         │ Max Latency: {async_max:.0f}ms               │
-        │ ⚠️  Queue buildup under load!    │
+        │ [!] Queue buildup under load!    │
         └─────────────────────────────────┘
 
         THREAD POOL (4 Workers):
@@ -556,7 +556,7 @@ class TestAsyncServerExplained:
         │ Completed: {threaded_server.stats.requests_completed}                    │
         │ Avg Latency: {threaded_avg:.0f}ms               │
         │ Max Latency: {threaded_max:.0f}ms               │
-        │ ✓  Handles load easily          │
+        │ [OK] Handles load easily        │
         └─────────────────────────────────┘
 
         KEY TAKEAWAY:
@@ -711,7 +711,7 @@ class TestAsyncServerExplained:
            │                                │
            │ Result: Requests REJECTED      │
            │ Rejected: {low_conn_server.stats.requests_rejected} requests          │
-           │ ⚠️  Connection limit hit!       │
+           │ [!] Connection limit hit!       │
            └────────────────────────────────┘
 
         2. CPU-LIMITED (Right plots):
@@ -723,7 +723,7 @@ class TestAsyncServerExplained:
            │                                │
            │ Result: QUEUE builds up        │
            │ Peak Queue: {max(slow_cpu_collector.async_cpu_queue_depth)}                  │
-           │ ⚠️  CPU is bottleneck!          │
+           │ [!] CPU is bottleneck!          │
            └────────────────────────────────┘
 
         KEY INSIGHT:
@@ -934,19 +934,19 @@ class TestAsyncServerExplained:
 
         REAL-WORLD EXAMPLES:
         ────────────────────
-        ❌ Synchronous file I/O
-        ❌ Complex regex on user input
-        ❌ JSON parsing large payloads
-        ❌ Image processing in request handler
-        ❌ Synchronous crypto operations
+        [X] Synchronous file I/O
+        [X] Complex regex on user input
+        [X] JSON parsing large payloads
+        [X] Image processing in request handler
+        [X] Synchronous crypto operations
 
         SOLUTIONS:
         ──────────
-        ✓ Use async/await for I/O
-        ✓ Offload CPU work to worker threads
-        ✓ Use streaming for large data
-        ✓ Set timeouts on operations
-        ✓ Use worker pools for CPU tasks
+        [OK] Use async/await for I/O
+        [OK] Offload CPU work to worker threads
+        [OK] Use streaming for large data
+        [OK] Set timeouts on operations
+        [OK] Use worker pools for CPU tasks
         """
         ax.text(0.02, 0.98, explanation, transform=ax.transAxes, fontsize=9,
                verticalalignment='top', fontfamily='monospace',

--- a/tests/integration/test_lru_algorithms_visualization.py
+++ b/tests/integration/test_lru_algorithms_visualization.py
@@ -554,7 +554,7 @@ SampledLRU: Random sample of N keys, evict oldest in sample.
         ax2.set_ylim(0, 100)
 
         plt.suptitle('SLRU Protected Ratio Analysis', fontsize=14)
-        plt.tight_layout(rect=[0, 0, 1, 0.95])
+        plt.subplots_adjust(top=0.92)
         plt.savefig(test_output_dir / 'slru_ratio_analysis.png', dpi=150)
         plt.close()
 


### PR DESCRIPTION
## Summary
- Replace emoji characters (`⚠️`, `✓`, `❌`) with ASCII equivalents (`[!]`, `[OK]`, `[X]`) in monospace `ax.text()` calls to avoid DejaVu Sans Mono font glyph warnings
- Guard `ax.legend()` calls in `gc_caused_collapse.py` with label existence checks to prevent empty legend warnings
- Replace `plt.tight_layout(rect=...)` with `plt.subplots_adjust(top=0.92)` in LRU visualization test to avoid decoration fitting warnings

## Test plan
- [x] `pytest tests/integration/test_async_server_explained.py -W error::UserWarning -q` — 7/7 passed
- [x] `pytest tests/integration/test_lru_algorithms_visualization.py -W error::UserWarning -q` — 3/3 passed
- [x] GC collapse test legend guard changes verified (4 pre-existing failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)