### PR TITLE
Add /line-count Claude skill

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(findstr:*)",
       "Bash(git log:*)",
       "Bash(Select-String:*)",
-      "Bash(Measure-Object -Line)"
+      "Bash(Measure-Object -Line)",
+      "Bash(cloc:*)"
     ]
   },
   "hooks": {

--- a/.claude/skills/line-count/SKILL.md
+++ b/.claude/skills/line-count/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: line-count
+description: Count lines of code using cloc with predefined scopes (source, tests, examples)
+---
+
+# Line Count
+
+Count lines of Python code in the project using `cloc`. Three predefined scopes are available.
+
+## Scopes
+
+| Scope | Argument | Directories | Command |
+|-------|----------|-------------|---------|
+| **Source only** | `src` | `happysimulator/` | `cloc happysimulator/ --exclude-dir=__pycache__,.egg-info` |
+| **Source + Tests** | `src+tests` | `happysimulator/`, `tests/` | `cloc happysimulator/ tests/ --exclude-dir=__pycache__,.egg-info` |
+| **All** | `all` | `happysimulator/`, `tests/`, `examples/` | `cloc happysimulator/ tests/ examples/ --exclude-dir=__pycache__,.egg-info` |
+
+## Instructions
+
+1. If the user provides a scope argument (`src`, `src+tests`, or `all`), run that scope directly
+2. If no argument is provided, ask the user which scope they want using these three options
+3. Run the appropriate `cloc` command from the project root
+4. Present the results in a summary table showing files, blank lines, comments, and code lines
+5. If multiple directories are included, also run each directory individually so the user can see a per-directory breakdown
+6. At the end, display a concise summary like:
+
+```
+Library (happysimulator/):  X,XXX lines
+Tests (tests/):             X,XXX lines
+Examples (examples/):       X,XXX lines
+──────────────────────────────────────
+Total:                      X,XXX lines
+```
+
+## Notes
+
+- Requires `cloc` to be installed and available on PATH
+- If `cloc` is not found, inform the user to install it (`choco install cloc`, `scoop install cloc`, or `pip install cloc`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -766,6 +766,7 @@ The following skills are available for use in this project:
 | `/code-review` | Review a pull request for issues and improvements |
 | `/gen-test` | Generate a pytest test following project conventions |
 | `/run-example` | Run a simulation example and analyze the output |
+| `/line-count` | Count lines of code using cloc (source, tests, examples) |
 | `/update-claudemd` | Review recent changes and update CLAUDE.md if needed |
 | `/update-pypi` | Bump the package version for PyPI release |
 | `/claude-automation-recommender` | Analyze codebase and recommend Claude Code automations |


### PR DESCRIPTION
## Summary
- Adds a new `/line-count` Claude skill that uses `cloc` to count lines of Python code
- Supports three scopes: source only (`src`), source + tests (`src+tests`), and all (`all` — includes examples)
- Provides per-directory breakdowns and a concise summary table
- Updates CLAUDE.md skills table and local settings to allow `cloc` commands

## Test plan
- [ ] Run `/line-count` with no argument — should prompt for scope selection
- [ ] Run `/line-count src` — should count only `happysimulator/`
- [ ] Run `/line-count src+tests` — should count `happysimulator/` and `tests/`
- [ ] Run `/line-count all` — should count all three directories with per-directory breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)