### PR TITLE
Add per-node clocks with skew and drift models

### DIFF
--- a/.dev/des-improvements.md
+++ b/.dev/des-improvements.md
@@ -315,7 +315,7 @@ I'd recommend this sequence, where each phase unlocks the next:
 | 1 | Event Cancellation ✅ | Clean timeout/timer patterns everywhere |
 | 2 | SimFuture ✅ | Natural request-response, resource acquire, lock acquire, quorum waits |
 | 3 | Logical Clocks | Pure algorithms, no engine changes needed |
-| 4 | Per-Node Clocks | Clock-sensitive protocol modeling |
+| 4 | Per-Node Clocks ✅ | Clock-sensitive protocol modeling |
 | 5 | Shared Resources ✅ | CPU/memory/disk contention (uses SimFuture) |
 | 6 | Network Topology | Graph abstraction over existing NetworkLink |
 | 7 | Fault Injection | Node crash, partition, degradation (uses Topology) |

--- a/happysimulator/__init__.py
+++ b/happysimulator/__init__.py
@@ -22,6 +22,10 @@ from happysimulator.core import (
     Simulation,
     Simulatable,
     simulatable,
+    ClockModel,
+    FixedSkew,
+    LinearDrift,
+    NodeClock,
     SimulationControl,
     SimulationState,
     BreakpointContext,
@@ -145,6 +149,11 @@ __all__ = [
     "SimFuture",
     "any_of",
     "all_of",
+    # Node clocks
+    "ClockModel",
+    "FixedSkew",
+    "LinearDrift",
+    "NodeClock",
     # Simulation control
     "SimulationControl",
     "SimulationState",

--- a/happysimulator/core/__init__.py
+++ b/happysimulator/core/__init__.py
@@ -10,6 +10,7 @@ from happysimulator.core.protocols import Simulatable, HasCapacity
 from happysimulator.core.decorators import simulatable
 from happysimulator.core.callback_entity import CallbackEntity, NullEntity
 from happysimulator.core.sim_future import SimFuture, any_of, all_of
+from happysimulator.core.node_clock import ClockModel, FixedSkew, LinearDrift, NodeClock
 from happysimulator.core.control import (
     SimulationControl,
     SimulationState,
@@ -40,6 +41,10 @@ __all__ = [
     "SimFuture",
     "any_of",
     "all_of",
+    "ClockModel",
+    "FixedSkew",
+    "LinearDrift",
+    "NodeClock",
     "SimulationControl",
     "SimulationState",
     "BreakpointContext",

--- a/happysimulator/core/node_clock.py
+++ b/happysimulator/core/node_clock.py
@@ -1,0 +1,163 @@
+"""Per-node clocks with skew and drift models.
+
+In real distributed systems, every node has its own clock with skew and drift.
+NodeClock transforms true simulation time into perceived local time, enabling
+modeling of clock-sensitive protocols (leader election, lease expiry, cache TTLs,
+distributed tracing).
+
+Key insight: NodeClock is a *view layer* over the shared Clock. Events are still
+ordered by true simulation time (the global Clock). NodeClock only transforms the
+read side — what an entity perceives as "now". This avoids causality issues.
+
+Usage::
+
+    from happysimulator import NodeClock, FixedSkew, LinearDrift, Duration
+
+    # Fixed offset: node clock is 50ms ahead of true time
+    clock = NodeClock(FixedSkew(Duration.from_seconds(0.05)))
+
+    # Drifting clock: 1000 ppm = 1ms drift per second
+    clock = NodeClock(LinearDrift(rate_ppm=1000))
+
+    # In an entity:
+    class RaftNode(Entity):
+        def __init__(self, name, node_clock):
+            super().__init__(name)
+            self._node_clock = node_clock
+
+        def set_clock(self, clock):
+            super().set_clock(clock)
+            self._node_clock.set_clock(clock)
+
+        @property
+        def local_now(self):
+            return self._node_clock.now
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from happysimulator.core.clock import Clock
+from happysimulator.core.temporal import Duration, Instant
+
+
+@runtime_checkable
+class ClockModel(Protocol):
+    """Protocol for time transformation models.
+
+    A ClockModel transforms true simulation time into perceived local time.
+    Implementations define how a node's clock deviates from the global clock.
+    """
+
+    def read(self, true_time: Instant) -> Instant:
+        """Transform true simulation time into perceived local time.
+
+        Args:
+            true_time: The actual simulation time from the global clock.
+
+        Returns:
+            The time as perceived by the node.
+        """
+        ...
+
+
+class FixedSkew:
+    """Constant time offset — clock is always ahead or behind by a fixed amount.
+
+    A positive offset means the clock reads ahead of true time (fast clock).
+    A negative offset means the clock reads behind true time (slow clock).
+
+    Args:
+        offset: The constant offset to apply. Positive = ahead, negative = behind.
+    """
+
+    def __init__(self, offset: Duration):
+        self._offset = offset
+
+    def read(self, true_time: Instant) -> Instant:
+        """Return true_time shifted by the fixed offset."""
+        return true_time + self._offset
+
+    @property
+    def offset(self) -> Duration:
+        """The fixed offset applied by this model."""
+        return self._offset
+
+
+class LinearDrift:
+    """Clock that runs faster or slower than true time, accumulating drift.
+
+    Drift is specified in parts per million (ppm). A rate of 1000 ppm means
+    the clock gains 1ms per second of elapsed true time. Negative ppm means
+    the clock runs slow.
+
+    The drift accumulates linearly: at true time T seconds from epoch,
+    the perceived time is T + (T * rate_ppm / 1_000_000) seconds.
+
+    Args:
+        rate_ppm: Drift rate in parts per million. Positive = fast, negative = slow.
+    """
+
+    def __init__(self, rate_ppm: float):
+        self._rate_ppm = rate_ppm
+
+    def read(self, true_time: Instant) -> Instant:
+        """Return true_time with accumulated linear drift."""
+        elapsed_ns = true_time.nanoseconds
+        drift_ns = int(elapsed_ns * self._rate_ppm / 1_000_000)
+        return Instant(elapsed_ns + drift_ns)
+
+    @property
+    def rate_ppm(self) -> float:
+        """The drift rate in parts per million."""
+        return self._rate_ppm
+
+
+class NodeClock:
+    """Per-node clock that transforms true simulation time via a ClockModel.
+
+    NodeClock wraps a base Clock (the shared simulation clock) and applies
+    a ClockModel to transform what the node perceives as "now". The base
+    clock is injected via set_clock(), typically forwarded from Entity.set_clock().
+
+    This is a plain class, NOT an Entity. Entities hold a NodeClock reference
+    and forward clock injection to it.
+
+    Args:
+        model: The clock model defining how time is transformed.
+            If None, the node clock returns true time (identity).
+    """
+
+    def __init__(self, model: ClockModel | None = None):
+        self._model = model
+        self._clock: Clock | None = None
+
+    def set_clock(self, clock: Clock) -> None:
+        """Inject the base simulation clock.
+
+        Args:
+            clock: The shared simulation clock to read true time from.
+        """
+        self._clock = clock
+
+    @property
+    def now(self) -> Instant:
+        """The perceived local time, transformed by the clock model.
+
+        Returns true time if no model is set.
+
+        Raises:
+            RuntimeError: If accessed before clock injection.
+        """
+        if self._clock is None:
+            raise RuntimeError("NodeClock has no base clock — call set_clock() first.")
+        true_time = self._clock.now
+        if self._model is None:
+            return true_time
+        return self._model.read(true_time)
+
+    @property
+    def model(self) -> ClockModel | None:
+        """The clock model, or None for identity."""
+        return self._model

--- a/tests/integration/test_node_clock_integration.py
+++ b/tests/integration/test_node_clock_integration.py
@@ -1,0 +1,444 @@
+"""Integration test: clock skew causes lease double-claim race condition.
+
+Demonstrates the classic distributed systems bug where clock skew causes two
+nodes to both believe they hold a lease simultaneously.
+
+Scenario:
+    - A LeaseCoordinator grants time-limited leases (TTL = 2s, using true time)
+    - Two LeaseNode entities compete for the lease, checking periodically
+    - Node A has a slow clock (-300ms skew): holds lease longer than it should
+    - Node B has a fast clock (+300ms skew): sees lease as expired earlier
+
+The race:
+    - Node A acquires at true t=0, lease expires at true t=2.0
+    - Node A's local time reads 2.0 at true t=2.3 (slow) -> holds lease 300ms too long
+    - Node B's local time reads 2.0 at true t=1.7 (fast) -> tries to acquire 300ms early
+    - Coordinator grants to B at true t=2.0 (server-side expiry is correct)
+    - Between true t=2.0 and t=2.3, both nodes believe they hold the lease
+
+Outputs:
+    - lease_race_condition.png (3-panel plot)
+    - lease_race_summary.json
+"""
+
+import json
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from happysimulator.core.entity import Entity
+from happysimulator.core.event import Event
+from happysimulator.core.node_clock import FixedSkew, NodeClock
+from happysimulator.core.simulation import Simulation
+from happysimulator.core.temporal import Duration, Instant
+
+
+# ---------------------------------------------------------------------------
+# Entities
+# ---------------------------------------------------------------------------
+
+
+class LeaseCoordinator(Entity):
+    """Central lease server that grants time-limited leases using true time.
+
+    Tracks who holds the lease and when it expires (both in true simulation time).
+    Nodes request leases; coordinator grants if no lease is active.
+    """
+
+    def __init__(self, name: str, ttl: float):
+        super().__init__(name)
+        self.ttl = ttl
+        self.holder: str | None = None
+        self.lease_expires_at: Instant = Instant.Epoch
+        # Event log: (true_time, event_type, node_name)
+        self.log: list[tuple[float, str, str]] = []
+
+    def handle_event(self, event: Event) -> list[Event] | None:
+        requester_name = event.context["node_name"]
+        reply_target = event.context["reply_target"]
+
+        now = self.now
+        granted = False
+
+        # Check if current lease has expired (using true time)
+        if self.holder is not None and now >= self.lease_expires_at:
+            self.log.append((now.to_seconds(), "expired", self.holder))
+            self.holder = None
+
+        if self.holder is None:
+            # Grant the lease
+            self.holder = requester_name
+            self.lease_expires_at = now + Duration.from_seconds(self.ttl)
+            self.log.append((now.to_seconds(), "granted", requester_name))
+            granted = True
+        elif self.holder == requester_name:
+            # Renewal
+            self.lease_expires_at = now + Duration.from_seconds(self.ttl)
+            self.log.append((now.to_seconds(), "renewed", requester_name))
+            granted = True
+        else:
+            self.log.append((now.to_seconds(), "denied", requester_name))
+
+        return [Event(
+            time=now,
+            event_type="LeaseResponse",
+            target=reply_target,
+            context={
+                "granted": granted,
+                "expires_at_s": self.lease_expires_at.to_seconds() if granted else 0,
+            },
+        )]
+
+
+class LeaseNode(Entity):
+    """Node that requests and holds leases, using its local clock for decisions.
+
+    Uses local_now (skewed) to decide when its lease has expired, simulating
+    a real node that only has access to its own wall clock.
+    """
+
+    def __init__(self, name: str, coordinator: LeaseCoordinator,
+                 node_clock: NodeClock, check_interval: float = 0.5):
+        super().__init__(name)
+        self.coordinator = coordinator
+        self._node_clock = node_clock
+        self.check_interval = check_interval
+        self.holds_lease = False
+        self.lease_expires_local: float = 0.0
+        # Records: (true_time, local_time, holds_lease)
+        self.history: list[tuple[float, float, bool]] = []
+
+    def set_clock(self, clock):
+        super().set_clock(clock)
+        self._node_clock.set_clock(clock)
+
+    @property
+    def local_now(self) -> Instant:
+        return self._node_clock.now
+
+    def handle_event(self, event: Event) -> list[Event] | None:
+        true_t = self.now.to_seconds()
+        local_t = self.local_now.to_seconds()
+
+        if event.event_type == "LeaseResponse":
+            granted = event.context["granted"]
+            if granted:
+                self.holds_lease = True
+                # Node computes expiry in its own local time
+                # The coordinator sent expires_at in true time; the node
+                # translates this to local time (which is wrong due to skew)
+                expires_true = event.context["expires_at_s"]
+                # Node thinks: "my local clock will read expires_true at the
+                # same moment true clock reads expires_true" — but it won't.
+                # This is the bug: the node assumes local time == true time.
+                self.lease_expires_local = expires_true
+            self.history.append((true_t, local_t, self.holds_lease))
+            return self._schedule_check()
+
+        if event.event_type == "Check":
+            # Check if we believe our lease has expired (using local clock)
+            if self.holds_lease and local_t >= self.lease_expires_local:
+                self.holds_lease = False
+
+            self.history.append((true_t, local_t, self.holds_lease))
+
+            if not self.holds_lease:
+                # Try to acquire
+                return [Event(
+                    time=self.now,
+                    event_type="LeaseRequest",
+                    target=self.coordinator,
+                    context={
+                        "node_name": self.name,
+                        "reply_target": self,
+                    },
+                )]
+            return self._schedule_check()
+
+        if event.event_type == "Start":
+            self.history.append((true_t, local_t, self.holds_lease))
+            return [Event(
+                time=self.now,
+                event_type="LeaseRequest",
+                target=self.coordinator,
+                context={
+                    "node_name": self.name,
+                    "reply_target": self,
+                },
+            )]
+
+        return []
+
+    def _schedule_check(self) -> list[Event]:
+        next_time = self.now + Duration.from_seconds(self.check_interval)
+        return [Event(
+            time=next_time,
+            event_type="Check",
+            target=self,
+        )]
+
+
+def _find_overlap_periods(
+    history_a: list[tuple[float, float, bool]],
+    history_b: list[tuple[float, float, bool]],
+) -> list[tuple[float, float]]:
+    """Find time ranges where both nodes believe they hold the lease.
+
+    Builds a timeline of lease-holding intervals for each node (by true time),
+    then finds overlaps.
+    """
+    def _holding_intervals(history: list[tuple[float, float, bool]]) -> list[tuple[float, float]]:
+        intervals = []
+        start = None
+        for true_t, _, holds in history:
+            if holds and start is None:
+                start = true_t
+            elif not holds and start is not None:
+                intervals.append((start, true_t))
+                start = None
+        if start is not None:
+            intervals.append((start, history[-1][0]))
+        return intervals
+
+    intervals_a = _holding_intervals(history_a)
+    intervals_b = _holding_intervals(history_b)
+
+    overlaps = []
+    for a_start, a_end in intervals_a:
+        for b_start, b_end in intervals_b:
+            overlap_start = max(a_start, b_start)
+            overlap_end = min(a_end, b_end)
+            if overlap_start < overlap_end:
+                overlaps.append((overlap_start, overlap_end))
+    return overlaps
+
+
+def _run_lease_simulation(
+    skew_a_s: float, skew_b_s: float, duration: float = 10.0,
+    ttl: float = 2.0, check_interval: float = 0.3,
+):
+    """Run the lease simulation with given skew values.
+
+    Returns (coordinator, node_a, node_b).
+    """
+    coordinator = LeaseCoordinator("Coordinator", ttl=ttl)
+
+    clock_a = NodeClock(FixedSkew(Duration.from_seconds(skew_a_s)))
+    clock_b = NodeClock(FixedSkew(Duration.from_seconds(skew_b_s)))
+
+    node_a = LeaseNode("NodeA", coordinator, clock_a, check_interval=check_interval)
+    node_b = LeaseNode("NodeB", coordinator, clock_b, check_interval=check_interval)
+
+    sim = Simulation(
+        end_time=Instant.from_seconds(duration),
+        entities=[coordinator, node_a, node_b],
+    )
+
+    # Kick off both nodes
+    sim.schedule(Event(
+        time=Instant.Epoch,
+        event_type="Start",
+        target=node_a,
+    ))
+    sim.schedule(Event(
+        time=Instant.from_seconds(0.1),
+        event_type="Start",
+        target=node_b,
+    ))
+
+    sim.run()
+    return coordinator, node_a, node_b
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLeaseRaceCondition:
+    """Clock skew causes a lease double-claim (split brain)."""
+
+    def test_skew_causes_overlap(self):
+        """With skew, both nodes believe they hold the lease simultaneously."""
+        coordinator, node_a, node_b = _run_lease_simulation(
+            skew_a_s=-0.3,  # slow clock
+            skew_b_s=+0.3,  # fast clock
+        )
+
+        overlaps = _find_overlap_periods(node_a.history, node_b.history)
+        assert len(overlaps) > 0, (
+            "Expected at least one overlap period where both nodes "
+            "believe they hold the lease"
+        )
+
+        # The overlap should be non-trivial
+        total_overlap = sum(end - start for start, end in overlaps)
+        assert total_overlap > 0.01, (
+            f"Overlap of {total_overlap:.4f}s is too small to be meaningful"
+        )
+
+    def test_no_skew_no_overlap(self):
+        """Without skew, no overlap occurs (control case)."""
+        coordinator, node_a, node_b = _run_lease_simulation(
+            skew_a_s=0.0,
+            skew_b_s=0.0,
+        )
+
+        overlaps = _find_overlap_periods(node_a.history, node_b.history)
+        assert len(overlaps) == 0, (
+            f"Expected no overlap without skew, but found: {overlaps}"
+        )
+
+
+class TestLeaseRaceVisualization:
+    """Generates a 3-panel visualization of the lease race condition."""
+
+    def test_visualization(self, test_output_dir: Path):
+        matplotlib = pytest.importorskip("matplotlib")
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import matplotlib.patches as mpatches
+
+        DURATION = 10.0
+        SKEW_A = -0.3
+        SKEW_B = +0.3
+        TTL = 2.0
+
+        coordinator, node_a, node_b = _run_lease_simulation(
+            skew_a_s=SKEW_A,
+            skew_b_s=SKEW_B,
+            duration=DURATION,
+            ttl=TTL,
+        )
+
+        overlaps = _find_overlap_periods(node_a.history, node_b.history)
+
+        # ── 3-panel plot ──
+        fig, axes = plt.subplots(3, 1, figsize=(14, 10), sharex=True)
+
+        # Panel 1: Lease holding timeline
+        ax1 = axes[0]
+        for hist, y, color, label in [
+            (node_a.history, 1.0, "#2196F3", f"Node A (skew={SKEW_A:+.1f}s)"),
+            (node_b.history, 0.0, "#FF9800", f"Node B (skew={SKEW_B:+.1f}s)"),
+        ]:
+            intervals = []
+            start = None
+            for true_t, _, holds in hist:
+                if holds and start is None:
+                    start = true_t
+                elif not holds and start is not None:
+                    intervals.append((start, true_t))
+                    start = None
+            if start is not None:
+                intervals.append((start, hist[-1][0]))
+
+            for s, e in intervals:
+                ax1.barh(y, e - s, left=s, height=0.4, color=color, alpha=0.7)
+            ax1.barh(y, 0, color=color, alpha=0.7, label=label)  # legend entry
+
+        # Highlight overlap regions
+        for o_start, o_end in overlaps:
+            ax1.axvspan(o_start, o_end, color="red", alpha=0.2)
+        if overlaps:
+            ax1.axvspan(0, 0, color="red", alpha=0.2, label="OVERLAP (split brain)")
+
+        ax1.set_yticks([0.0, 1.0])
+        ax1.set_yticklabels(["Node B", "Node A"])
+        ax1.set_ylabel("Lease Holder")
+        ax1.set_title(
+            f"Lease Double-Claim Race Condition\n"
+            f"TTL={TTL}s, Node A skew={SKEW_A:+.1f}s, Node B skew={SKEW_B:+.1f}s"
+        )
+        ax1.legend(loc="upper right", fontsize=8)
+        ax1.grid(True, alpha=0.3, axis="x")
+
+        # Panel 2: Local clock readings vs true time
+        ax2 = axes[1]
+        for hist, color, label in [
+            (node_a.history, "#2196F3", "Node A local clock"),
+            (node_b.history, "#FF9800", "Node B local clock"),
+        ]:
+            true_times = [t for t, _, _ in hist]
+            local_times = [lt for _, lt, _ in hist]
+            ax2.plot(true_times, local_times, color=color, linewidth=1.2, label=label)
+
+        # True time reference line
+        ax2.plot([0, DURATION], [0, DURATION], "k--", alpha=0.4, label="True time")
+        ax2.set_ylabel("Local Clock Reading (s)")
+        ax2.set_title("Clock Divergence")
+        ax2.legend(loc="upper left", fontsize=8)
+        ax2.grid(True, alpha=0.3)
+
+        # Panel 3: Coordinator event log
+        ax3 = axes[2]
+        event_colors = {
+            "granted": "#4CAF50",
+            "renewed": "#8BC34A",
+            "denied": "#F44336",
+            "expired": "#9E9E9E",
+        }
+        event_markers = {
+            "granted": "^",
+            "renewed": "s",
+            "denied": "x",
+            "expired": "v",
+        }
+        for true_t, etype, node_name in coordinator.log:
+            y = 1.0 if node_name == "NodeA" else 0.0
+            ax3.scatter(
+                true_t, y,
+                color=event_colors.get(etype, "black"),
+                marker=event_markers.get(etype, "o"),
+                s=60, zorder=5,
+            )
+
+        # Legend for event types
+        legend_handles = [
+            mpatches.Patch(color=c, label=e.capitalize())
+            for e, c in event_colors.items()
+        ]
+        ax3.legend(handles=legend_handles, loc="upper right", fontsize=8)
+        ax3.set_yticks([0.0, 1.0])
+        ax3.set_yticklabels(["Node B", "Node A"])
+        ax3.set_ylabel("Node")
+        ax3.set_xlabel("True Simulation Time (s)")
+        ax3.set_title("Coordinator Events")
+        ax3.grid(True, alpha=0.3, axis="x")
+
+        plt.tight_layout()
+        plot_path = test_output_dir / "lease_race_condition.png"
+        fig.savefig(plot_path, dpi=150)
+        plt.close(fig)
+
+        assert plot_path.exists()
+        assert plot_path.stat().st_size > 1000
+
+        # ── Save summary JSON ──
+        total_overlap = sum(e - s for s, e in overlaps)
+        summary = {
+            "config": {
+                "duration_s": DURATION,
+                "ttl_s": TTL,
+                "skew_a_s": SKEW_A,
+                "skew_b_s": SKEW_B,
+            },
+            "results": {
+                "overlap_count": len(overlaps),
+                "total_overlap_s": round(total_overlap, 6),
+                "overlaps": [
+                    {"start_s": round(s, 6), "end_s": round(e, 6)}
+                    for s, e in overlaps
+                ],
+                "coordinator_events": len(coordinator.log),
+                "node_a_history_points": len(node_a.history),
+                "node_b_history_points": len(node_b.history),
+            },
+        }
+        json_path = test_output_dir / "lease_race_summary.json"
+        with open(json_path, "w") as f:
+            json.dump(summary, f, indent=2)
+
+        assert json_path.exists()
+        assert len(overlaps) > 0, "Visualization should show overlaps"

--- a/tests/unit/test_node_clock.py
+++ b/tests/unit/test_node_clock.py
@@ -1,0 +1,165 @@
+"""Unit tests for per-node clocks and clock models."""
+
+from happysimulator.core.clock import Clock
+from happysimulator.core.node_clock import (
+    ClockModel,
+    FixedSkew,
+    LinearDrift,
+    NodeClock,
+)
+from happysimulator.core.temporal import Duration, Instant
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# FixedSkew
+# ---------------------------------------------------------------------------
+
+
+class TestFixedSkew:
+
+    def test_positive_offset_reads_ahead(self):
+        """A positive offset makes the clock read ahead of true time."""
+        skew = FixedSkew(Duration.from_seconds(0.3))
+        true_time = Instant.from_seconds(10.0)
+        perceived = skew.read(true_time)
+        assert perceived == Instant.from_seconds(10.3)
+
+    def test_negative_offset_reads_behind(self):
+        """A negative offset makes the clock read behind true time."""
+        skew = FixedSkew(Duration.from_seconds(-0.3))
+        true_time = Instant.from_seconds(10.0)
+        perceived = skew.read(true_time)
+        assert perceived == Instant.from_seconds(9.7)
+
+    def test_zero_offset_is_identity(self):
+        """Zero offset returns true time unchanged."""
+        skew = FixedSkew(Duration.ZERO)
+        true_time = Instant.from_seconds(5.0)
+        assert skew.read(true_time) == true_time
+
+    def test_offset_property(self):
+        offset = Duration.from_seconds(0.05)
+        skew = FixedSkew(offset)
+        assert skew.offset == offset
+
+    def test_offset_at_epoch(self):
+        """Offset applies even at time zero."""
+        skew = FixedSkew(Duration.from_seconds(0.1))
+        perceived = skew.read(Instant.Epoch)
+        assert perceived == Instant.from_seconds(0.1)
+
+    def test_implements_clock_model_protocol(self):
+        assert isinstance(FixedSkew(Duration.ZERO), ClockModel)
+
+
+# ---------------------------------------------------------------------------
+# LinearDrift
+# ---------------------------------------------------------------------------
+
+
+class TestLinearDrift:
+
+    def test_positive_ppm_clock_runs_fast(self):
+        """Positive ppm means the clock gains time — reads ahead."""
+        drift = LinearDrift(rate_ppm=1000)  # 1ms per second
+        true_time = Instant.from_seconds(10.0)
+        perceived = drift.read(true_time)
+        # 10s * 1000/1_000_000 = 0.01s drift
+        expected = Instant.from_seconds(10.01)
+        assert perceived == expected
+
+    def test_negative_ppm_clock_runs_slow(self):
+        """Negative ppm means the clock loses time — reads behind."""
+        drift = LinearDrift(rate_ppm=-1000)
+        true_time = Instant.from_seconds(10.0)
+        perceived = drift.read(true_time)
+        expected = Instant.from_seconds(9.99)
+        assert perceived == expected
+
+    def test_zero_drift_is_identity(self):
+        """Zero ppm returns true time unchanged."""
+        drift = LinearDrift(rate_ppm=0)
+        true_time = Instant.from_seconds(42.0)
+        assert drift.read(true_time) == true_time
+
+    def test_drift_accumulates_over_time(self):
+        """Drift grows linearly with elapsed time."""
+        drift = LinearDrift(rate_ppm=1000)
+        at_1s = drift.read(Instant.from_seconds(1.0))
+        at_10s = drift.read(Instant.from_seconds(10.0))
+        at_100s = drift.read(Instant.from_seconds(100.0))
+
+        drift_1 = at_1s.to_seconds() - 1.0
+        drift_10 = at_10s.to_seconds() - 10.0
+        drift_100 = at_100s.to_seconds() - 100.0
+
+        # Drift should be proportional to elapsed time
+        assert abs(drift_10 / drift_1 - 10.0) < 0.01
+        assert abs(drift_100 / drift_1 - 100.0) < 0.01
+
+    def test_drift_at_epoch_is_zero(self):
+        """No drift at time zero regardless of rate."""
+        drift = LinearDrift(rate_ppm=5000)
+        assert drift.read(Instant.Epoch) == Instant.Epoch
+
+    def test_rate_ppm_property(self):
+        drift = LinearDrift(rate_ppm=500)
+        assert drift.rate_ppm == 500
+
+    def test_implements_clock_model_protocol(self):
+        assert isinstance(LinearDrift(rate_ppm=0), ClockModel)
+
+
+# ---------------------------------------------------------------------------
+# NodeClock
+# ---------------------------------------------------------------------------
+
+
+class TestNodeClock:
+
+    def _make_clock(self, time_s: float = 0.0) -> Clock:
+        """Create a Clock set to the given time."""
+        clock = Clock(Instant.from_seconds(time_s))
+        return clock
+
+    def test_now_returns_transformed_time(self):
+        """NodeClock.now applies the model to the base clock's time."""
+        base = self._make_clock(10.0)
+        nc = NodeClock(FixedSkew(Duration.from_seconds(0.5)))
+        nc.set_clock(base)
+        assert nc.now == Instant.from_seconds(10.5)
+
+    def test_now_without_model_returns_true_time(self):
+        """NodeClock with no model acts as identity."""
+        base = self._make_clock(7.0)
+        nc = NodeClock()
+        nc.set_clock(base)
+        assert nc.now == Instant.from_seconds(7.0)
+
+    def test_raises_without_base_clock(self):
+        """Accessing now before set_clock raises RuntimeError."""
+        nc = NodeClock(FixedSkew(Duration.ZERO))
+        with pytest.raises(RuntimeError, match="no base clock"):
+            _ = nc.now
+
+    def test_tracks_clock_updates(self):
+        """NodeClock reflects updates to the underlying base clock."""
+        base = self._make_clock(0.0)
+        nc = NodeClock(FixedSkew(Duration.from_seconds(1.0)))
+        nc.set_clock(base)
+
+        assert nc.now == Instant.from_seconds(1.0)
+
+        base.update(Instant.from_seconds(5.0))
+        assert nc.now == Instant.from_seconds(6.0)
+
+    def test_model_property(self):
+        model = LinearDrift(rate_ppm=100)
+        nc = NodeClock(model)
+        assert nc.model is model
+
+    def test_model_property_none(self):
+        nc = NodeClock()
+        assert nc.model is None


### PR DESCRIPTION
## Summary
- Add `NodeClock`, `ClockModel` protocol, `FixedSkew`, and `LinearDrift` classes for per-node clock simulation
- NodeClock is a view layer over the shared Clock — events still use true time, but entities can perceive skewed/drifted local time
- Includes lease double-claim integration test demonstrating split-brain caused by clock skew, with 3-panel visualization
- 19 unit tests + 3 integration tests, full suite passes with no regressions

## Test plan
- [x] Unit tests for FixedSkew (positive/negative/zero offset, protocol compliance)
- [x] Unit tests for LinearDrift (positive/negative/zero ppm, drift accumulation)
- [x] Unit tests for NodeClock (transformed time, identity, error handling, clock updates)
- [x] Integration test: clock skew causes lease overlap (split brain)
- [x] Integration test: zero skew produces no overlap (control case)
- [x] Integration test: 3-panel visualization output
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)