### PR TITLE
Add logical clocks: Lamport, Vector, HLC

### DIFF
--- a/.dev/des-improvements.md
+++ b/.dev/des-improvements.md
@@ -314,7 +314,7 @@ I'd recommend this sequence, where each phase unlocks the next:
 |-------|------|---------|
 | 1 | Event Cancellation ✅ | Clean timeout/timer patterns everywhere |
 | 2 | SimFuture ✅ | Natural request-response, resource acquire, lock acquire, quorum waits |
-| 3 | Logical Clocks | Pure algorithms, no engine changes needed |
+| 3 | Logical Clocks ✅ | Pure algorithms, no engine changes needed |
 | 4 | Per-Node Clocks ✅ | Clock-sensitive protocol modeling |
 | 5 | Shared Resources ✅ | CPU/memory/disk contention (uses SimFuture) |
 | 6 | Network Topology ✅ | Partition handles, asymmetric partitions, traffic_matrix(), public API exports |

--- a/happysimulator/__init__.py
+++ b/happysimulator/__init__.py
@@ -26,6 +26,10 @@ from happysimulator.core import (
     FixedSkew,
     LinearDrift,
     NodeClock,
+    LamportClock,
+    VectorClock,
+    HLCTimestamp,
+    HybridLogicalClock,
     SimulationControl,
     SimulationState,
     BreakpointContext,
@@ -167,6 +171,11 @@ __all__ = [
     "FixedSkew",
     "LinearDrift",
     "NodeClock",
+    # Logical clocks
+    "LamportClock",
+    "VectorClock",
+    "HLCTimestamp",
+    "HybridLogicalClock",
     # Simulation control
     "SimulationControl",
     "SimulationState",

--- a/happysimulator/core/__init__.py
+++ b/happysimulator/core/__init__.py
@@ -11,6 +11,12 @@ from happysimulator.core.decorators import simulatable
 from happysimulator.core.callback_entity import CallbackEntity, NullEntity
 from happysimulator.core.sim_future import SimFuture, any_of, all_of
 from happysimulator.core.node_clock import ClockModel, FixedSkew, LinearDrift, NodeClock
+from happysimulator.core.logical_clocks import (
+    HLCTimestamp,
+    HybridLogicalClock,
+    LamportClock,
+    VectorClock,
+)
 from happysimulator.core.control import (
     SimulationControl,
     SimulationState,
@@ -45,6 +51,10 @@ __all__ = [
     "FixedSkew",
     "LinearDrift",
     "NodeClock",
+    "LamportClock",
+    "VectorClock",
+    "HLCTimestamp",
+    "HybridLogicalClock",
     "SimulationControl",
     "SimulationState",
     "BreakpointContext",

--- a/happysimulator/core/logical_clocks.py
+++ b/happysimulator/core/logical_clocks.py
@@ -1,0 +1,410 @@
+"""Logical clocks for distributed systems simulation.
+
+Provides three classic logical clock algorithms used in distributed systems:
+
+- **LamportClock**: Monotonic counter for total ordering (Lamport 1978).
+- **VectorClock**: Per-node counters for causal ordering (Fidge/Mattern 1988).
+- **HybridLogicalClock**: Physical + logical components (Kulkarni et al. 2014).
+
+These are pure algorithm classes — not Entities. Entities store them as fields
+and call their methods during event handling, exactly like ``NodeClock`` and
+``FixedSkew``/``LinearDrift``.
+
+Usage::
+
+    from happysimulator import LamportClock, VectorClock, HybridLogicalClock
+
+    # Lamport: simple monotonic counter
+    clock = LamportClock()
+    clock.tick()           # Local event
+    ts = clock.send()      # Returns timestamp to embed in message
+    clock.receive(ts)      # max(local, remote) + 1
+
+    # Vector clock: per-node counters for causal ordering
+    vc = VectorClock("node-1", ["node-1", "node-2", "node-3"])
+    vc.tick()
+    snapshot = vc.send()   # dict[str, int] to embed in message
+    vc.receive(snapshot)   # Element-wise max + increment own
+
+    # HLC: physical + logical (CockroachDB/Spanner-style)
+    hlc = HybridLogicalClock("node-1", physical_clock=node_clock)
+    ts = hlc.now()         # HLCTimestamp(physical_ns, logical, node_id)
+    hlc.receive(remote_ts)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from happysimulator.core.node_clock import NodeClock
+from happysimulator.core.temporal import Instant
+
+
+# =============================================================================
+# Lamport Clock
+# =============================================================================
+
+
+class LamportClock:
+    """Monotonic counter for establishing total ordering of events.
+
+    Each local event increments the counter. When sending a message, the
+    current counter is included. On receive, the counter advances to
+    ``max(local, remote) + 1``, ensuring causal ordering.
+
+    Args:
+        initial: Starting counter value (default 0).
+    """
+
+    __slots__ = ("_time",)
+
+    def __init__(self, initial: int = 0):
+        self._time = initial
+
+    @property
+    def time(self) -> int:
+        """Current counter value."""
+        return self._time
+
+    def tick(self) -> None:
+        """Record a local event (increment counter)."""
+        self._time += 1
+
+    def send(self) -> int:
+        """Increment counter and return timestamp to embed in a message."""
+        self._time += 1
+        return self._time
+
+    def receive(self, remote_ts: int) -> None:
+        """Update counter on receiving a message.
+
+        Sets counter to ``max(local, remote) + 1``.
+
+        Args:
+            remote_ts: The Lamport timestamp from the received message.
+        """
+        self._time = max(self._time, remote_ts) + 1
+
+
+# =============================================================================
+# Vector Clock
+# =============================================================================
+
+
+class VectorClock:
+    """Per-node counters for determining causal ordering between events.
+
+    Each node maintains a vector of counters (one per node in the system).
+    The ``happened_before`` relation enables detecting causally related vs.
+    concurrent events — fundamental to conflict detection in replicated
+    datastores (Dynamo, Riak) and consistency verification.
+
+    Args:
+        node_id: This node's identifier.
+        node_ids: All node identifiers in the system (including this node).
+    """
+
+    __slots__ = ("_node_id", "_vector")
+
+    def __init__(self, node_id: str, node_ids: list[str]):
+        self._node_id = node_id
+        self._vector: dict[str, int] = {nid: 0 for nid in node_ids}
+        if node_id not in self._vector:
+            self._vector[node_id] = 0
+
+    @property
+    def node_id(self) -> str:
+        """This node's identifier."""
+        return self._node_id
+
+    def tick(self) -> None:
+        """Record a local event (increment own counter)."""
+        self._vector[self._node_id] += 1
+
+    def send(self) -> dict[str, int]:
+        """Increment own counter and return a snapshot for embedding in a message."""
+        self._vector[self._node_id] += 1
+        return dict(self._vector)
+
+    def receive(self, remote: dict[str, int]) -> None:
+        """Update vector on receiving a message.
+
+        Takes the element-wise max of local and remote vectors, then
+        increments own counter.
+
+        Args:
+            remote: The vector clock snapshot from the received message.
+        """
+        for nid, ts in remote.items():
+            if nid in self._vector:
+                self._vector[nid] = max(self._vector[nid], ts)
+            else:
+                self._vector[nid] = ts
+        self._vector[self._node_id] += 1
+
+    def snapshot(self) -> dict[str, int]:
+        """Return a frozen copy of the current vector."""
+        return dict(self._vector)
+
+    def happened_before(self, other: VectorClock) -> bool:
+        """Test if this clock causally precedes ``other``.
+
+        Returns True if all components of this vector are <= the
+        corresponding components of ``other``, and at least one is
+        strictly less.
+
+        Args:
+            other: The vector clock to compare against.
+        """
+        all_keys = set(self._vector) | set(other._vector)
+        all_leq = True
+        any_lt = False
+        for k in all_keys:
+            local_val = self._vector.get(k, 0)
+            other_val = other._vector.get(k, 0)
+            if local_val > other_val:
+                all_leq = False
+                break
+            if local_val < other_val:
+                any_lt = True
+        return all_leq and any_lt
+
+    def is_concurrent(self, other: VectorClock) -> bool:
+        """Test if this clock and ``other`` are concurrent (neither happened-before).
+
+        Args:
+            other: The vector clock to compare against.
+        """
+        return not self.happened_before(other) and not other.happened_before(self)
+
+    def merge(self, other: VectorClock) -> VectorClock:
+        """Create a new VectorClock with element-wise max (no increment).
+
+        Unlike ``receive()``, this does NOT increment the local counter.
+        Useful for read-only merges (e.g., computing a combined view).
+
+        Args:
+            other: The vector clock to merge with.
+
+        Returns:
+            A new VectorClock with the merged vector.
+        """
+        all_keys = sorted(set(self._vector) | set(other._vector))
+        merged = VectorClock(self._node_id, all_keys)
+        for k in all_keys:
+            merged._vector[k] = max(
+                self._vector.get(k, 0),
+                other._vector.get(k, 0),
+            )
+        return merged
+
+
+# =============================================================================
+# HLC Timestamp
+# =============================================================================
+
+
+@dataclass(frozen=True, order=False)
+class HLCTimestamp:
+    """Immutable timestamp from a Hybrid Logical Clock.
+
+    Total ordering is defined by ``(physical_ns, logical, node_id)``.
+
+    Attributes:
+        physical_ns: Nanosecond wall-clock component.
+        logical: Logical counter within the same physical tick.
+        node_id: Originating node identifier.
+    """
+
+    physical_ns: int
+    logical: int
+    node_id: str
+
+    def __lt__(self, other: HLCTimestamp) -> bool:
+        return (self.physical_ns, self.logical, self.node_id) < (
+            other.physical_ns,
+            other.logical,
+            other.node_id,
+        )
+
+    def __le__(self, other: HLCTimestamp) -> bool:
+        return (self.physical_ns, self.logical, self.node_id) <= (
+            other.physical_ns,
+            other.logical,
+            other.node_id,
+        )
+
+    def __gt__(self, other: HLCTimestamp) -> bool:
+        return (self.physical_ns, self.logical, self.node_id) > (
+            other.physical_ns,
+            other.logical,
+            other.node_id,
+        )
+
+    def __ge__(self, other: HLCTimestamp) -> bool:
+        return (self.physical_ns, self.logical, self.node_id) >= (
+            other.physical_ns,
+            other.logical,
+            other.node_id,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, HLCTimestamp):
+            return NotImplemented
+        return (self.physical_ns, self.logical, self.node_id) == (
+            other.physical_ns,
+            other.logical,
+            other.node_id,
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.physical_ns, self.logical, self.node_id))
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dict for embedding in event contexts."""
+        return {
+            "physical_ns": self.physical_ns,
+            "logical": self.logical,
+            "node_id": self.node_id,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> HLCTimestamp:
+        """Deserialize from a plain dict.
+
+        Args:
+            d: Dict with keys ``physical_ns``, ``logical``, ``node_id``.
+        """
+        return cls(
+            physical_ns=d["physical_ns"],
+            logical=d["logical"],
+            node_id=d["node_id"],
+        )
+
+
+# =============================================================================
+# Hybrid Logical Clock
+# =============================================================================
+
+
+class HybridLogicalClock:
+    """Hybrid Logical Clock combining physical and logical components.
+
+    HLC provides the best of both worlds: timestamps that respect causality
+    (like Lamport clocks) while staying close to physical time (enabling
+    bounded-staleness reads). Used in CockroachDB, Spanner, and similar
+    systems.
+
+    The physical component comes from either a ``NodeClock`` (for skew
+    modeling) or a plain callable returning an ``Instant``.
+
+    Algorithm (Kulkarni et al. 2014):
+
+    - **now/send**: Read physical time ``pt``. If ``pt > last.physical_ns``,
+      reset logical to 0. Otherwise keep physical from last and increment
+      logical. Return ``(pt, logical, node_id)``.
+    - **receive**: Take max of physical time, last physical, and remote
+      physical. Adjust logical based on which components tied.
+
+    Args:
+        node_id: This node's identifier.
+        physical_clock: A ``NodeClock`` to read perceived time from.
+            Mutually exclusive with ``wall_time``.
+        wall_time: A callable returning the current ``Instant``.
+            Mutually exclusive with ``physical_clock``.
+
+    Raises:
+        ValueError: If both or neither time source is provided.
+    """
+
+    __slots__ = ("_node_id", "_get_physical_ns", "_last")
+
+    def __init__(
+        self,
+        node_id: str,
+        physical_clock: NodeClock | None = None,
+        wall_time: Callable[[], Instant] | None = None,
+    ):
+        if physical_clock is not None and wall_time is not None:
+            raise ValueError(
+                "Provide either physical_clock or wall_time, not both."
+            )
+        if physical_clock is None and wall_time is None:
+            raise ValueError(
+                "Provide either physical_clock or wall_time."
+            )
+
+        self._node_id = node_id
+
+        if physical_clock is not None:
+            self._get_physical_ns: Callable[[], int] = (
+                lambda: physical_clock.now.nanoseconds
+            )
+        else:
+            assert wall_time is not None
+            self._get_physical_ns = lambda: wall_time().nanoseconds
+
+        self._last = HLCTimestamp(physical_ns=0, logical=0, node_id=node_id)
+
+    @property
+    def node_id(self) -> str:
+        """This node's identifier."""
+        return self._node_id
+
+    def now(self) -> HLCTimestamp:
+        """Generate a timestamp for the current instant.
+
+        Reads the physical clock and advances the logical component
+        if the physical time hasn't changed since the last call.
+        """
+        pt = self._get_physical_ns()
+        if pt > self._last.physical_ns:
+            self._last = HLCTimestamp(
+                physical_ns=pt, logical=0, node_id=self._node_id
+            )
+        else:
+            self._last = HLCTimestamp(
+                physical_ns=self._last.physical_ns,
+                logical=self._last.logical + 1,
+                node_id=self._node_id,
+            )
+        return self._last
+
+    def send(self) -> HLCTimestamp:
+        """Generate a timestamp to embed in an outgoing message.
+
+        Equivalent to ``now()`` — included for API symmetry with
+        ``LamportClock`` and ``VectorClock``.
+        """
+        return self.now()
+
+    def receive(self, remote: HLCTimestamp) -> None:
+        """Update clock state on receiving a remote timestamp.
+
+        Implements the HLC receive algorithm: takes the max of physical
+        time, last local physical, and remote physical, then adjusts the
+        logical component based on which values tied.
+
+        Args:
+            remote: The HLC timestamp from the received message.
+        """
+        pt = self._get_physical_ns()
+        max_pt = max(pt, self._last.physical_ns, remote.physical_ns)
+
+        if max_pt == self._last.physical_ns == remote.physical_ns:
+            # All three tied — advance logical past both
+            logical = max(self._last.logical, remote.logical) + 1
+        elif max_pt == self._last.physical_ns:
+            # Local physical wins or ties with pt (but not remote)
+            logical = self._last.logical + 1
+        elif max_pt == remote.physical_ns:
+            # Remote physical wins (but not local)
+            logical = remote.logical + 1
+        else:
+            # Physical time advanced past both — reset logical
+            logical = 0
+
+        self._last = HLCTimestamp(
+            physical_ns=max_pt, logical=logical, node_id=self._node_id
+        )

--- a/tests/integration/test_logical_clocks_integration.py
+++ b/tests/integration/test_logical_clocks_integration.py
@@ -1,0 +1,442 @@
+"""Integration test: 3-node distributed counter with logical clocks.
+
+Scenario:
+- 3 CounterNode entities (A, B, C) connected via full-mesh Network
+- Each node has a different NodeClock skew
+- Nodes periodically tick and send updates with all three clock types
+  (Lamport, VectorClock, HLC) embedded in event context metadata
+- Verifies causal ordering properties across all clock types
+
+Visualization (3 panels):
+1. Lamport timestamps per node over true time
+2. Vector clock magnitude (sum of vector) per node over time
+3. HLC physical vs logical components per node
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from happysimulator.components.network.conditions import datacenter_network
+from happysimulator.components.network.network import Network
+from happysimulator.core.entity import Entity
+from happysimulator.core.event import Event
+from happysimulator.core.logical_clocks import (
+    HybridLogicalClock,
+    LamportClock,
+    VectorClock,
+)
+from happysimulator.core.node_clock import FixedSkew, NodeClock
+from happysimulator.core.simulation import Simulation
+from happysimulator.core.temporal import Duration, Instant
+
+
+# =============================================================================
+# Entities
+# =============================================================================
+
+
+@dataclass
+class CounterNode(Entity):
+    """Node that ticks all three logical clocks and sends updates to peers.
+
+    Each tick:
+    1. Increments Lamport, VectorClock, and HLC
+    2. Sends a message to a random peer with all three timestamps
+    3. Records history for visualization and assertion
+    """
+
+    name: str
+    network: Network | None = None
+    peers: list[CounterNode] = field(default_factory=list)
+    tick_interval: float = 0.5
+
+    # Logical clocks (set after construction for NodeClock wiring)
+    lamport: LamportClock = field(default_factory=LamportClock)
+    vector: VectorClock | None = field(default=None, init=False)
+    hlc: HybridLogicalClock | None = field(default=None, init=False)
+    node_clock: NodeClock | None = field(default=None, init=False)
+
+    # History for assertions and visualization
+    lamport_history: list[tuple[float, int]] = field(
+        default_factory=list, init=False
+    )
+    vector_history: list[tuple[float, dict[str, int]]] = field(
+        default_factory=list, init=False
+    )
+    hlc_history: list[tuple[float, int, int]] = field(
+        default_factory=list, init=False
+    )
+
+    def set_clock(self, clock):
+        super().set_clock(clock)
+        if self.node_clock is not None:
+            self.node_clock.set_clock(clock)
+
+    def start(self) -> list[Event]:
+        return [
+            Event(
+                time=Instant.from_seconds(self.tick_interval),
+                event_type="Tick",
+                target=self,
+                daemon=True,
+            )
+        ]
+
+    def handle_event(self, event: Event) -> list[Event] | None:
+        if event.event_type == "Tick":
+            return self._handle_tick()
+        elif event.event_type == "Update":
+            return self._handle_update(event)
+        return None
+
+    def _handle_tick(self) -> list[Event]:
+        events: list[Event] = []
+        t = self.now.to_seconds()
+
+        # Tick all clocks
+        self.lamport.tick()
+        self.vector.tick()
+        hlc_ts = self.hlc.now()
+
+        # Record history
+        self.lamport_history.append((t, self.lamport.time))
+        self.vector_history.append((t, self.vector.snapshot()))
+        self.hlc_history.append((t, hlc_ts.physical_ns, hlc_ts.logical))
+
+        # Send update to a random peer
+        if self.peers and self.network is not None:
+            peer = random.choice(self.peers)
+            lamport_ts = self.lamport.send()
+            vector_snap = self.vector.send()
+            hlc_send_ts = self.hlc.send()
+
+            msg_event = self.network.send(
+                source=self,
+                destination=peer,
+                event_type="Update",
+                payload={
+                    "lamport_ts": lamport_ts,
+                    "vector_snap": vector_snap,
+                    "hlc_ts": hlc_send_ts.to_dict(),
+                    "origin": self.name,
+                },
+                daemon=True,
+            )
+            events.append(msg_event)
+
+        # Schedule next tick
+        events.append(
+            Event(
+                time=Instant.from_seconds(t + self.tick_interval),
+                event_type="Tick",
+                target=self,
+                daemon=True,
+            )
+        )
+        return events
+
+    def _handle_update(self, event: Event) -> None:
+        metadata = event.context.get("metadata", {})
+        t = self.now.to_seconds()
+
+        # Update all clocks from received message
+        self.lamport.receive(metadata["lamport_ts"])
+        self.vector.receive(metadata["vector_snap"])
+
+        from happysimulator.core.logical_clocks import HLCTimestamp
+
+        remote_hlc = HLCTimestamp.from_dict(metadata["hlc_ts"])
+        self.hlc.receive(remote_hlc)
+
+        # Record post-receive state
+        self.lamport_history.append((t, self.lamport.time))
+        self.vector_history.append((t, self.vector.snapshot()))
+        hlc_now = self.hlc._last
+        self.hlc_history.append((t, hlc_now.physical_ns, hlc_now.logical))
+
+        return None
+
+
+# =============================================================================
+# Setup
+# =============================================================================
+
+
+def _build_cluster() -> tuple[Network, list[CounterNode]]:
+    """Build a 3-node cluster with different clock skews."""
+    node_names = ["A", "B", "C"]
+    network = Network(name="LogicalClockNet")
+
+    # Different clock skews per node
+    skews = {
+        "A": Duration.from_seconds(0.0),     # Perfect clock
+        "B": Duration.from_seconds(0.05),     # 50ms ahead
+        "C": Duration.from_seconds(-0.03),    # 30ms behind
+    }
+
+    nodes = []
+    for name in node_names:
+        node_clock = NodeClock(FixedSkew(skews[name]))
+        node = CounterNode(name=name, network=network, tick_interval=0.3)
+        node.node_clock = node_clock
+        node.lamport = LamportClock()
+        nodes.append(node)
+
+    # Set up vector clocks and HLCs (need all node names)
+    for node in nodes:
+        node.vector = VectorClock(node.name, node_names)
+        node.hlc = HybridLogicalClock(
+            node.name, physical_clock=node.node_clock
+        )
+
+    # Wire peers
+    for node in nodes:
+        node.peers = [n for n in nodes if n is not node]
+
+    # Full mesh with datacenter links
+    for i, src in enumerate(nodes):
+        for dst in nodes[i + 1 :]:
+            link = datacenter_network(name=f"link_{src.name}_{dst.name}")
+            network.add_bidirectional_link(src, dst, link)
+
+    return network, nodes
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestLogicalClocksIntegration:
+    def test_lamport_causality(self):
+        """Every received event's Lamport ts < receiver's post-receive ts."""
+        random.seed(42)
+        network, nodes = _build_cluster()
+
+        sim = Simulation(
+            start_time=Instant.Epoch,
+            end_time=Instant.from_seconds(10.0),
+            sources=[],
+            entities=[network, *nodes],
+        )
+
+        for node in nodes:
+            for evt in node.start():
+                sim.schedule(evt)
+
+        sim.run()
+
+        # Each node's Lamport history should be monotonically non-decreasing
+        for node in nodes:
+            times = [ts for _, ts in node.lamport_history]
+            for i in range(1, len(times)):
+                assert times[i] >= times[i - 1], (
+                    f"Node {node.name} Lamport not monotonic at index {i}: "
+                    f"{times[i-1]} -> {times[i]}"
+                )
+
+        # All nodes should have non-zero Lamport timestamps
+        for node in nodes:
+            assert node.lamport.time > 0, (
+                f"Node {node.name} Lamport is still 0"
+            )
+
+    def test_vector_clock_concurrent_detection(self):
+        """Concurrent events detected when nodes haven't communicated."""
+        random.seed(123)
+        network, nodes = _build_cluster()
+        node_map = {n.name: n for n in nodes}
+
+        sim = Simulation(
+            start_time=Instant.Epoch,
+            end_time=Instant.from_seconds(5.0),
+            sources=[],
+            entities=[network, *nodes],
+        )
+
+        for node in nodes:
+            for evt in node.start():
+                sim.schedule(evt)
+
+        sim.run()
+
+        # After the simulation, verify vector clock properties:
+        # 1. Each node's own component should be the highest in its vector
+        for node in nodes:
+            snap = node.vector.snapshot()
+            own_val = snap[node.name]
+            assert own_val > 0, f"Node {node.name} has 0 own component"
+
+        # 2. Vector clocks should reflect communication
+        # (non-zero components for peers that sent messages)
+        for node in nodes:
+            snap = node.vector.snapshot()
+            has_peer_info = any(
+                v > 0 for k, v in snap.items() if k != node.name
+            )
+            assert has_peer_info, (
+                f"Node {node.name} has no peer info: {snap}"
+            )
+
+    def test_hlc_monotonicity_despite_skew(self):
+        """All HLC timestamps from same node are strictly monotonic despite clock skew."""
+        random.seed(42)
+        network, nodes = _build_cluster()
+
+        sim = Simulation(
+            start_time=Instant.Epoch,
+            end_time=Instant.from_seconds(10.0),
+            sources=[],
+            entities=[network, *nodes],
+        )
+
+        for node in nodes:
+            for evt in node.start():
+                sim.schedule(evt)
+
+        sim.run()
+
+        for node in nodes:
+            history = node.hlc_history
+            assert len(history) > 1, (
+                f"Node {node.name} has too few HLC entries"
+            )
+
+            for i in range(1, len(history)):
+                _, phys_prev, log_prev = history[i - 1]
+                _, phys_curr, log_curr = history[i]
+
+                # Timestamps must be non-decreasing in (physical, logical)
+                assert (phys_curr, log_curr) >= (phys_prev, log_prev), (
+                    f"Node {node.name} HLC not monotonic at index {i}: "
+                    f"({phys_prev}, {log_prev}) -> ({phys_curr}, {log_curr})"
+                )
+
+    def test_full_scenario_with_visualization(self, test_output_dir: Path):
+        """Full 3-node scenario with all clock types and 3-panel visualization."""
+        random.seed(42)
+        network, nodes = _build_cluster()
+
+        sim = Simulation(
+            start_time=Instant.Epoch,
+            end_time=Instant.from_seconds(15.0),
+            sources=[],
+            entities=[network, *nodes],
+        )
+
+        for node in nodes:
+            for evt in node.start():
+                sim.schedule(evt)
+
+        sim.run()
+
+        # Basic assertions
+        for node in nodes:
+            assert node.lamport.time > 0
+            assert len(node.hlc_history) > 5
+
+        # Generate visualization
+        _generate_visualization(nodes, test_output_dir)
+
+
+# =============================================================================
+# Visualization
+# =============================================================================
+
+
+def _generate_visualization(
+    nodes: list[CounterNode],
+    output_dir: Path,
+) -> None:
+    """Generate 3-panel visualization of logical clock behavior."""
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, axes = plt.subplots(3, 1, figsize=(14, 12))
+
+    node_colors = {"A": "#e74c3c", "B": "#3498db", "C": "#2ecc71"}
+
+    # Panel 1: Lamport timestamps per node over true time
+    ax1 = axes[0]
+    for node in nodes:
+        if node.lamport_history:
+            times = [t for t, _ in node.lamport_history]
+            values = [v for _, v in node.lamport_history]
+            ax1.plot(
+                times,
+                values,
+                label=f"Node {node.name}",
+                color=node_colors[node.name],
+                linewidth=1.5,
+                marker=".",
+                markersize=3,
+            )
+    ax1.set_title("Lamport Timestamps per Node")
+    ax1.set_xlabel("True Simulation Time (s)")
+    ax1.set_ylabel("Lamport Counter")
+    ax1.legend(loc="upper left", fontsize=8)
+    ax1.grid(True, alpha=0.3)
+
+    # Panel 2: Vector clock magnitude (sum of vector) per node
+    ax2 = axes[1]
+    for node in nodes:
+        if node.vector_history:
+            times = [t for t, _ in node.vector_history]
+            magnitudes = [sum(v.values()) for _, v in node.vector_history]
+            ax2.plot(
+                times,
+                magnitudes,
+                label=f"Node {node.name}",
+                color=node_colors[node.name],
+                linewidth=1.5,
+                marker=".",
+                markersize=3,
+            )
+    ax2.set_title("Vector Clock Magnitude (sum of all components)")
+    ax2.set_xlabel("True Simulation Time (s)")
+    ax2.set_ylabel("Sum of Vector Components")
+    ax2.legend(loc="upper left", fontsize=8)
+    ax2.grid(True, alpha=0.3)
+
+    # Panel 3: HLC physical vs logical per node
+    ax3 = axes[2]
+    for node in nodes:
+        if node.hlc_history:
+            times = [t for t, _, _ in node.hlc_history]
+            physical_ms = [p / 1_000_000 for _, p, _ in node.hlc_history]
+            logical = [l for _, _, l in node.hlc_history]
+
+            ax3.plot(
+                times,
+                physical_ms,
+                label=f"Node {node.name} physical",
+                color=node_colors[node.name],
+                linewidth=1.5,
+            )
+            ax3_twin = ax3.twinx() if node.name == "A" else ax3_twin
+            ax3_twin.plot(
+                times,
+                logical,
+                label=f"Node {node.name} logical",
+                color=node_colors[node.name],
+                linewidth=1.0,
+                linestyle="--",
+                alpha=0.6,
+            )
+
+    ax3.set_title("HLC: Physical (solid) and Logical (dashed) Components")
+    ax3.set_xlabel("True Simulation Time (s)")
+    ax3.set_ylabel("Physical Component (ms)")
+    ax3_twin.set_ylabel("Logical Counter")
+    ax3.legend(loc="upper left", fontsize=8)
+    ax3.grid(True, alpha=0.3)
+
+    fig.tight_layout()
+    fig.savefig(output_dir / "logical_clocks_analysis.png", dpi=150)
+    plt.close(fig)

--- a/tests/unit/core/test_logical_clocks.py
+++ b/tests/unit/core/test_logical_clocks.py
@@ -1,0 +1,480 @@
+"""Unit tests for logical clocks (Lamport, Vector, HLC)."""
+
+from __future__ import annotations
+
+import pytest
+
+from happysimulator.core.logical_clocks import (
+    HLCTimestamp,
+    HybridLogicalClock,
+    LamportClock,
+    VectorClock,
+)
+from happysimulator.core.node_clock import NodeClock
+from happysimulator.core.temporal import Instant
+
+
+# =============================================================================
+# LamportClock
+# =============================================================================
+
+
+class TestLamportClock:
+    def test_initial_time_is_zero(self):
+        clock = LamportClock()
+        assert clock.time == 0
+
+    def test_initial_time_custom(self):
+        clock = LamportClock(initial=10)
+        assert clock.time == 10
+
+    def test_tick_increments(self):
+        clock = LamportClock()
+        clock.tick()
+        assert clock.time == 1
+        clock.tick()
+        assert clock.time == 2
+
+    def test_send_increments_and_returns(self):
+        clock = LamportClock()
+        ts = clock.send()
+        assert ts == 1
+        assert clock.time == 1
+        ts2 = clock.send()
+        assert ts2 == 2
+
+    def test_receive_advances_past_remote(self):
+        clock = LamportClock()
+        clock.receive(5)
+        assert clock.time == 6  # max(0, 5) + 1
+
+    def test_receive_when_local_is_higher(self):
+        clock = LamportClock(initial=10)
+        clock.receive(3)
+        assert clock.time == 11  # max(10, 3) + 1
+
+    def test_receive_when_equal(self):
+        clock = LamportClock(initial=5)
+        clock.receive(5)
+        assert clock.time == 6  # max(5, 5) + 1
+
+    def test_send_receive_preserves_causality(self):
+        """Sending and receiving should preserve happens-before."""
+        a = LamportClock()
+        b = LamportClock()
+
+        # A sends to B
+        ts = a.send()
+        b.receive(ts)
+        assert b.time > ts  # B's time is after A's sent timestamp
+
+        # B sends back to A
+        ts2 = b.send()
+        a.receive(ts2)
+        assert a.time > ts2  # A's time is after B's sent timestamp
+
+    def test_multiple_rounds(self):
+        a = LamportClock()
+        b = LamportClock()
+        c = LamportClock()
+
+        # A ticks locally
+        a.tick()
+        a.tick()
+        assert a.time == 2
+
+        # A sends to B
+        ts = a.send()  # A=3
+        b.receive(ts)   # B = max(0, 3) + 1 = 4
+
+        # B sends to C
+        ts2 = b.send()  # B=5
+        c.receive(ts2)   # C = max(0, 5) + 1 = 6
+
+        assert c.time == 6
+        assert c.time > b.time - 1  # C received after B sent
+
+
+# =============================================================================
+# VectorClock
+# =============================================================================
+
+
+class TestVectorClock:
+    def test_initial_vector_is_zeros(self):
+        vc = VectorClock("A", ["A", "B", "C"])
+        assert vc.snapshot() == {"A": 0, "B": 0, "C": 0}
+
+    def test_tick_increments_own(self):
+        vc = VectorClock("A", ["A", "B"])
+        vc.tick()
+        assert vc.snapshot() == {"A": 1, "B": 0}
+
+    def test_send_increments_and_returns_copy(self):
+        vc = VectorClock("A", ["A", "B"])
+        snap = vc.send()
+        assert snap == {"A": 1, "B": 0}
+        # Mutating returned dict doesn't affect internal state
+        snap["A"] = 999
+        assert vc.snapshot()["A"] == 1
+
+    def test_receive_takes_elementwise_max_and_increments(self):
+        vc = VectorClock("A", ["A", "B", "C"])
+        vc.tick()  # A={A:1, B:0, C:0}
+
+        remote = {"A": 0, "B": 3, "C": 2}
+        vc.receive(remote)
+        # max then increment own: A=1+1=2, B=max(0,3)=3, C=max(0,2)=2
+        assert vc.snapshot() == {"A": 2, "B": 3, "C": 2}
+
+    def test_happened_before_true(self):
+        a = VectorClock("A", ["A", "B"])
+        b = VectorClock("B", ["A", "B"])
+
+        ts = a.send()  # A={A:1, B:0}
+        b.receive(ts)   # B={A:1, B:1}
+
+        # a happened before b (a's state at send time was {A:1, B:0})
+        assert a.happened_before(b)
+
+    def test_happened_before_false_when_concurrent(self):
+        a = VectorClock("A", ["A", "B"])
+        b = VectorClock("B", ["A", "B"])
+
+        a.tick()  # A={A:1, B:0}
+        b.tick()  # B={A:0, B:1}
+
+        assert not a.happened_before(b)
+        assert not b.happened_before(a)
+
+    def test_happened_before_false_when_after(self):
+        a = VectorClock("A", ["A", "B"])
+        b = VectorClock("B", ["A", "B"])
+
+        ts = a.send()
+        b.receive(ts)
+
+        assert not b.happened_before(a)
+
+    def test_is_concurrent(self):
+        a = VectorClock("A", ["A", "B"])
+        b = VectorClock("B", ["A", "B"])
+
+        a.tick()  # Independent local events
+        b.tick()
+
+        assert a.is_concurrent(b)
+        assert b.is_concurrent(a)
+
+    def test_not_concurrent_after_communication(self):
+        a = VectorClock("A", ["A", "B"])
+        b = VectorClock("B", ["A", "B"])
+
+        ts = a.send()
+        b.receive(ts)
+
+        assert not a.is_concurrent(b)
+
+    def test_merge_returns_new_clock_no_increment(self):
+        a = VectorClock("A", ["A", "B", "C"])
+        b = VectorClock("B", ["A", "B", "C"])
+
+        a.tick()  # {A:1, B:0, C:0}
+        b.tick()  # {A:0, B:1, C:0}
+        b.tick()  # {A:0, B:2, C:0}
+
+        merged = a.merge(b)
+        assert merged.snapshot() == {"A": 1, "B": 2, "C": 0}
+        # Original clocks unchanged
+        assert a.snapshot() == {"A": 1, "B": 0, "C": 0}
+        assert b.snapshot() == {"A": 0, "B": 2, "C": 0}
+
+    def test_merge_preserves_node_id(self):
+        a = VectorClock("A", ["A", "B"])
+        b = VectorClock("B", ["A", "B"])
+        merged = a.merge(b)
+        assert merged.node_id == "A"
+
+    def test_node_id_property(self):
+        vc = VectorClock("node-1", ["node-1", "node-2"])
+        assert vc.node_id == "node-1"
+
+    def test_receive_with_unknown_node(self):
+        """Receive from a node not in the original set."""
+        vc = VectorClock("A", ["A", "B"])
+        vc.receive({"A": 0, "B": 0, "C": 5})
+        snap = vc.snapshot()
+        assert snap["C"] == 5
+        assert snap["A"] == 1  # Own counter incremented
+
+    def test_three_node_causal_chain(self):
+        """A -> B -> C: C knows about A's event."""
+        a = VectorClock("A", ["A", "B", "C"])
+        b = VectorClock("B", ["A", "B", "C"])
+        c = VectorClock("C", ["A", "B", "C"])
+
+        ts_ab = a.send()   # A={A:1, B:0, C:0}
+        b.receive(ts_ab)    # B={A:1, B:1, C:0}
+        ts_bc = b.send()    # B={A:1, B:2, C:0}
+        c.receive(ts_bc)     # C={A:1, B:2, C:1}
+
+        assert a.happened_before(c)
+        assert b.happened_before(c)
+
+    def test_equal_vectors_not_happened_before(self):
+        """Equal vectors: neither happened before the other, but not concurrent either."""
+        a = VectorClock("A", ["A", "B"])
+        b = VectorClock("B", ["A", "B"])
+        # Both at {A:0, B:0}
+        assert not a.happened_before(b)
+        assert not b.happened_before(a)
+        # Equal vectors are NOT concurrent by the standard definition
+        # (concurrent = neither happened-before, which IS the case here)
+        # But since both are {0,0}, technically they're the "same" event
+        assert a.is_concurrent(b)
+
+
+# =============================================================================
+# HLCTimestamp
+# =============================================================================
+
+
+class TestHLCTimestamp:
+    def test_ordering_by_physical(self):
+        a = HLCTimestamp(physical_ns=100, logical=0, node_id="A")
+        b = HLCTimestamp(physical_ns=200, logical=0, node_id="A")
+        assert a < b
+        assert b > a
+
+    def test_ordering_by_logical(self):
+        a = HLCTimestamp(physical_ns=100, logical=0, node_id="A")
+        b = HLCTimestamp(physical_ns=100, logical=1, node_id="A")
+        assert a < b
+
+    def test_ordering_by_node_id(self):
+        a = HLCTimestamp(physical_ns=100, logical=0, node_id="A")
+        b = HLCTimestamp(physical_ns=100, logical=0, node_id="B")
+        assert a < b
+
+    def test_equality(self):
+        a = HLCTimestamp(physical_ns=100, logical=5, node_id="X")
+        b = HLCTimestamp(physical_ns=100, logical=5, node_id="X")
+        assert a == b
+        assert not (a != b)
+
+    def test_inequality(self):
+        a = HLCTimestamp(physical_ns=100, logical=5, node_id="X")
+        b = HLCTimestamp(physical_ns=100, logical=6, node_id="X")
+        assert a != b
+
+    def test_hash_equal(self):
+        a = HLCTimestamp(physical_ns=100, logical=5, node_id="X")
+        b = HLCTimestamp(physical_ns=100, logical=5, node_id="X")
+        assert hash(a) == hash(b)
+        assert len({a, b}) == 1
+
+    def test_le_ge(self):
+        a = HLCTimestamp(physical_ns=100, logical=0, node_id="A")
+        b = HLCTimestamp(physical_ns=100, logical=0, node_id="A")
+        assert a <= b
+        assert a >= b
+
+    def test_to_dict(self):
+        ts = HLCTimestamp(physical_ns=1_000_000, logical=3, node_id="node-1")
+        d = ts.to_dict()
+        assert d == {
+            "physical_ns": 1_000_000,
+            "logical": 3,
+            "node_id": "node-1",
+        }
+
+    def test_from_dict(self):
+        d = {"physical_ns": 1_000_000, "logical": 3, "node_id": "node-1"}
+        ts = HLCTimestamp.from_dict(d)
+        assert ts.physical_ns == 1_000_000
+        assert ts.logical == 3
+        assert ts.node_id == "node-1"
+
+    def test_roundtrip(self):
+        original = HLCTimestamp(physical_ns=42, logical=7, node_id="z")
+        assert HLCTimestamp.from_dict(original.to_dict()) == original
+
+    def test_frozen(self):
+        ts = HLCTimestamp(physical_ns=1, logical=2, node_id="A")
+        with pytest.raises(AttributeError):
+            ts.physical_ns = 99  # type: ignore[misc]
+
+
+# =============================================================================
+# HybridLogicalClock
+# =============================================================================
+
+
+class TestHybridLogicalClock:
+    @staticmethod
+    def _make_wall(ns_values: list[int]) -> tuple:
+        """Create a wall_time callable that returns successive Instant values."""
+        it = iter(ns_values)
+
+        def wall_time() -> Instant:
+            return Instant(next(it))
+
+        return wall_time
+
+    def test_requires_time_source(self):
+        with pytest.raises(ValueError, match="Provide either"):
+            HybridLogicalClock("A")
+
+    def test_rejects_both_time_sources(self):
+        clock = NodeClock()
+        with pytest.raises(ValueError, match="not both"):
+            HybridLogicalClock(
+                "A",
+                physical_clock=clock,
+                wall_time=lambda: Instant(0),
+            )
+
+    def test_now_advances_physical(self):
+        wall = self._make_wall([100, 200, 300])
+        hlc = HybridLogicalClock("A", wall_time=wall)
+
+        ts1 = hlc.now()
+        assert ts1.physical_ns == 100
+        assert ts1.logical == 0
+
+        ts2 = hlc.now()
+        assert ts2.physical_ns == 200
+        assert ts2.logical == 0
+
+    def test_now_increments_logical_when_physical_unchanged(self):
+        wall = self._make_wall([100, 100, 100])
+        hlc = HybridLogicalClock("A", wall_time=wall)
+
+        ts1 = hlc.now()
+        assert ts1 == HLCTimestamp(100, 0, "A")
+
+        ts2 = hlc.now()
+        assert ts2 == HLCTimestamp(100, 1, "A")
+
+        ts3 = hlc.now()
+        assert ts3 == HLCTimestamp(100, 2, "A")
+
+    def test_send_is_alias_for_now(self):
+        wall = self._make_wall([100, 200])
+        hlc = HybridLogicalClock("A", wall_time=wall)
+
+        ts = hlc.send()
+        assert ts == HLCTimestamp(100, 0, "A")
+
+    def test_receive_remote_physical_ahead(self):
+        """Remote has higher physical: adopt remote physical, logical = remote.logical + 1."""
+        wall = self._make_wall([100, 100])
+        hlc = HybridLogicalClock("A", wall_time=wall)
+        hlc.now()  # Consume first wall read: last=(100, 0, A)
+
+        remote = HLCTimestamp(physical_ns=200, logical=5, node_id="B")
+        hlc.receive(remote)
+        # pt=100, last=100, remote=200 → max=200 = remote only
+        # logical = remote.logical + 1 = 6
+        ts = hlc._last
+        assert ts.physical_ns == 200
+        assert ts.logical == 6
+
+    def test_receive_local_physical_ahead(self):
+        """Local last has higher physical: keep local, logical = last.logical + 1."""
+        wall = self._make_wall([200, 200])
+        hlc = HybridLogicalClock("A", wall_time=wall)
+        hlc.now()  # last=(200, 0, A)
+
+        remote = HLCTimestamp(physical_ns=100, logical=5, node_id="B")
+        hlc.receive(remote)
+        # pt=200, last=200, remote=100 → max=200 = last (and pt)
+        # Since max_pt == last.physical_ns and max_pt != remote.physical_ns
+        # logical = last.logical + 1 = 1
+        ts = hlc._last
+        assert ts.physical_ns == 200
+        assert ts.logical == 1
+
+    def test_receive_all_physical_equal(self):
+        """All three physical values equal: logical = max(last.logical, remote.logical) + 1."""
+        wall = self._make_wall([100, 100])
+        hlc = HybridLogicalClock("A", wall_time=wall)
+        hlc.now()  # last=(100, 0, A)
+
+        remote = HLCTimestamp(physical_ns=100, logical=3, node_id="B")
+        hlc.receive(remote)
+        # All three = 100, logical = max(0, 3) + 1 = 4
+        ts = hlc._last
+        assert ts.physical_ns == 100
+        assert ts.logical == 4
+
+    def test_receive_physical_advances_past_both(self):
+        """Current physical time exceeds both last and remote: reset logical."""
+        wall = self._make_wall([100, 500])
+        hlc = HybridLogicalClock("A", wall_time=wall)
+        hlc.now()  # last=(100, 0, A)
+
+        remote = HLCTimestamp(physical_ns=200, logical=10, node_id="B")
+        hlc.receive(remote)
+        # pt=500, last=100, remote=200 → max=500 = pt only
+        # logical = 0 (fresh physical time)
+        ts = hlc._last
+        assert ts.physical_ns == 500
+        assert ts.logical == 0
+
+    def test_monotonicity_despite_clock_regression(self):
+        """Even if physical clock goes backward, timestamps stay monotonic."""
+        wall = self._make_wall([100, 50, 50])
+        hlc = HybridLogicalClock("A", wall_time=wall)
+
+        ts1 = hlc.now()  # (100, 0, A)
+        ts2 = hlc.now()  # pt=50 < last.pt=100 → keep 100, logical=1
+        ts3 = hlc.now()  # pt=50 < last.pt=100 → keep 100, logical=2
+
+        assert ts1 < ts2 < ts3
+
+    def test_node_id_property(self):
+        wall = self._make_wall([0])
+        hlc = HybridLogicalClock("node-42", wall_time=wall)
+        assert hlc.node_id == "node-42"
+
+    def test_node_id_in_timestamps(self):
+        wall = self._make_wall([100])
+        hlc = HybridLogicalClock("node-X", wall_time=wall)
+        ts = hlc.now()
+        assert ts.node_id == "node-X"
+
+    def test_with_node_clock(self):
+        """HLC can use a NodeClock for physical time."""
+        from happysimulator.core.clock import Clock
+
+        clock = Clock(start_time=Instant.from_seconds(1.0))
+
+        node_clock = NodeClock()
+        node_clock.set_clock(clock)
+
+        hlc = HybridLogicalClock("A", physical_clock=node_clock)
+        ts = hlc.now()
+        assert ts.physical_ns == Instant.from_seconds(1.0).nanoseconds
+
+    def test_two_node_exchange(self):
+        """Two nodes exchange messages, timestamps stay monotonic per node."""
+        wall_a = self._make_wall([100, 100, 200, 200, 300])
+        wall_b = self._make_wall([150, 150, 250, 250, 350])
+
+        a = HybridLogicalClock("A", wall_time=wall_a)
+        b = HybridLogicalClock("B", wall_time=wall_b)
+
+        # A sends to B
+        ts_a1 = a.send()  # (100, 0, A)
+        b.receive(ts_a1)   # B reads pt=150, last=this receive result
+
+        # B sends to A
+        ts_b1 = b.send()
+        a.receive(ts_b1)
+
+        # A sends again
+        ts_a2 = a.send()
+
+        # All of A's timestamps are strictly monotonic
+        assert ts_a1 < ts_a2


### PR DESCRIPTION
## Summary
- Adds three classic logical clock algorithms for distributed systems simulation (Phase 3 from `.dev/des-improvements.md`)
- **LamportClock**: monotonic counter for total ordering with `tick()`, `send()`, `receive()`
- **VectorClock**: per-node counters with `happened_before()`, `is_concurrent()`, `merge()` for causal ordering and conflict detection
- **HLCTimestamp** + **HybridLogicalClock**: physical+logical timestamps (Kulkarni et al. 2014) with `NodeClock` integration for clock skew modeling
- Pure algorithm classes (not Entities) — stored as entity fields, like `NodeClock`/`FixedSkew`
- 49 unit tests + 4 integration tests (3-node cluster with visualization), full suite passes (1772 tests)

## Test plan
- [x] Unit tests: `pytest tests/unit/core/test_logical_clocks.py -q` (49 pass)
- [x] Integration tests: `pytest tests/integration/test_logical_clocks_integration.py -q` (4 pass)
- [x] Full regression suite: `python -m pytest -q` (1772 pass, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)