### PR TITLE
Add causal event graph for parent-child tracking

### DIFF
--- a/happysimulator/__init__.py
+++ b/happysimulator/__init__.py
@@ -117,6 +117,13 @@ from happysimulator.instrumentation import (
     ThroughputTracker,
 )
 
+# Analysis
+from happysimulator.analysis import (
+    CausalGraph,
+    CausalNode,
+    build_causal_graph,
+)
+
 # Sketching algorithms
 from happysimulator.sketching import (
     TopK,
@@ -253,6 +260,10 @@ __all__ = [
     "QueueStats",
     "SimulationSummary",
     "ThroughputTracker",
+    # Analysis
+    "CausalGraph",
+    "CausalNode",
+    "build_causal_graph",
     # Sketching algorithms
     "TopK",
     "CountMinSketch",

--- a/happysimulator/analysis/__init__.py
+++ b/happysimulator/analysis/__init__.py
@@ -16,6 +16,11 @@ from happysimulator.analysis.report import (
     SimulationAnalysis,
     analyze,
 )
+from happysimulator.analysis.causal_graph import (
+    CausalGraph,
+    CausalNode,
+    build_causal_graph,
+)
 
 __all__ = [
     "Phase",
@@ -27,4 +32,7 @@ __all__ = [
     "MetricSummary",
     "SimulationAnalysis",
     "analyze",
+    "CausalGraph",
+    "CausalNode",
+    "build_causal_graph",
 ]

--- a/happysimulator/analysis/causal_graph.py
+++ b/happysimulator/analysis/causal_graph.py
@@ -1,0 +1,298 @@
+"""Causal event graph for post-simulation analysis.
+
+Builds a directed acyclic graph of "event A caused event B" relationships
+from trace recorder data. Events created during another event's invoke()
+automatically have their ``parent_id`` set, forming parent-child edges.
+
+Usage::
+
+    from happysimulator import Simulation, InMemoryTraceRecorder
+    from happysimulator.analysis import build_causal_graph
+
+    recorder = InMemoryTraceRecorder()
+    sim = Simulation(..., trace_recorder=recorder)
+    sim.run()
+
+    graph = build_causal_graph(recorder)
+    # or: graph = sim.causal_graph()
+
+    for root in graph.roots():
+        print(f"Root: {root.event_type} at {root.time}")
+    print(f"Critical path length: {len(graph.critical_path())}")
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Any, Callable, TYPE_CHECKING
+
+from happysimulator.core.temporal import Instant
+
+if TYPE_CHECKING:
+    from happysimulator.instrumentation.recorder import InMemoryTraceRecorder
+
+
+@dataclass(frozen=True)
+class CausalNode:
+    """A node in the causal event graph.
+
+    Attributes:
+        event_id: Unique event identifier (from context["id"]).
+        event_type: Human-readable event type label.
+        time: Simulation time when the event was scheduled.
+        parent_id: ID of the event that caused this one, or None for roots.
+    """
+
+    event_id: str
+    event_type: str
+    time: Instant
+    parent_id: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dictionary."""
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "time_s": self.time.to_seconds(),
+            "parent_id": self.parent_id,
+        }
+
+
+class CausalGraph:
+    """Directed acyclic graph of causal event relationships.
+
+    Nodes are events; edges point from parent (cause) to child (effect).
+    Built from trace recorder ``simulation.schedule`` spans that carry
+    ``parent_id`` metadata.
+
+    Args:
+        nodes: Mapping of event_id to CausalNode.
+    """
+
+    def __init__(self, nodes: dict[str, CausalNode]) -> None:
+        self._nodes = nodes
+
+        # Build adjacency indexes
+        self._children: dict[str, list[str]] = defaultdict(list)
+        self._root_ids: list[str] = []
+
+        for node in nodes.values():
+            if node.parent_id is not None and node.parent_id in nodes:
+                self._children[node.parent_id].append(node.event_id)
+            else:
+                self._root_ids.append(node.event_id)
+
+        # Sort roots by time for deterministic ordering
+        self._root_ids.sort(key=lambda eid: self._nodes[eid].time)
+
+    @property
+    def nodes(self) -> dict[str, CausalNode]:
+        """All nodes keyed by event_id."""
+        return self._nodes
+
+    def __len__(self) -> int:
+        return len(self._nodes)
+
+    def __contains__(self, event_id: str) -> bool:
+        return event_id in self._nodes
+
+    def parent(self, event_id: str) -> CausalNode | None:
+        """Return the parent node, or None if this is a root."""
+        node = self._nodes[event_id]
+        if node.parent_id is not None and node.parent_id in self._nodes:
+            return self._nodes[node.parent_id]
+        return None
+
+    def children(self, event_id: str) -> list[CausalNode]:
+        """Return direct children of the given event."""
+        return [self._nodes[cid] for cid in self._children.get(event_id, [])]
+
+    def ancestors(self, event_id: str) -> list[CausalNode]:
+        """Return the chain from parent to root (nearest first)."""
+        result: list[CausalNode] = []
+        current = self._nodes[event_id]
+        while current.parent_id is not None and current.parent_id in self._nodes:
+            current = self._nodes[current.parent_id]
+            result.append(current)
+        return result
+
+    def descendants(self, event_id: str) -> list[CausalNode]:
+        """Return all descendants via BFS (breadth-first)."""
+        result: list[CausalNode] = []
+        queue: deque[str] = deque(self._children.get(event_id, []))
+        while queue:
+            cid = queue.popleft()
+            result.append(self._nodes[cid])
+            queue.extend(self._children.get(cid, []))
+        return result
+
+    def roots(self) -> list[CausalNode]:
+        """Return all root nodes (events with no parent in the graph)."""
+        return [self._nodes[rid] for rid in self._root_ids]
+
+    def leaves(self) -> list[CausalNode]:
+        """Return all leaf nodes (events with no children)."""
+        return [
+            node for node in self._nodes.values()
+            if not self._children.get(node.event_id)
+        ]
+
+    def depth(self, event_id: str) -> int:
+        """Return the distance from the root (root = 0)."""
+        d = 0
+        current = self._nodes[event_id]
+        while current.parent_id is not None and current.parent_id in self._nodes:
+            current = self._nodes[current.parent_id]
+            d += 1
+        return d
+
+    def critical_path(self) -> list[CausalNode]:
+        """Return the longest causal chain in the graph.
+
+        Uses topological ordering + dynamic programming on the DAG.
+        Returns the full path from root to leaf of maximum length.
+        """
+        if not self._nodes:
+            return []
+
+        # Compute in-degree for topological sort
+        in_degree: dict[str, int] = {eid: 0 for eid in self._nodes}
+        for eid, children_ids in self._children.items():
+            for cid in children_ids:
+                if cid in in_degree:
+                    in_degree[cid] += 1
+
+        # Kahn's algorithm for topological order
+        topo_order: list[str] = []
+        queue: deque[str] = deque(
+            eid for eid, deg in in_degree.items() if deg == 0
+        )
+        while queue:
+            eid = queue.popleft()
+            topo_order.append(eid)
+            for cid in self._children.get(eid, []):
+                if cid in in_degree:
+                    in_degree[cid] -= 1
+                    if in_degree[cid] == 0:
+                        queue.append(cid)
+
+        # DP: longest path from any root to each node
+        dist: dict[str, int] = {eid: 0 for eid in self._nodes}
+        pred: dict[str, str | None] = {eid: None for eid in self._nodes}
+
+        for eid in topo_order:
+            for cid in self._children.get(eid, []):
+                if cid in dist and dist[eid] + 1 > dist[cid]:
+                    dist[cid] = dist[eid] + 1
+                    pred[cid] = eid
+
+        # Find the endpoint of the longest path
+        end_id = max(dist, key=lambda eid: dist[eid])
+
+        # Reconstruct path
+        path_ids: list[str] = []
+        current: str | None = end_id
+        while current is not None:
+            path_ids.append(current)
+            current = pred[current]
+        path_ids.reverse()
+
+        return [self._nodes[eid] for eid in path_ids]
+
+    def filter(self, predicate: Callable[[CausalNode], bool]) -> CausalGraph:
+        """Return a new graph containing only nodes matching the predicate.
+
+        Parent links are re-linked: if a node's parent is excluded, the
+        node searches up the ancestor chain for the nearest included
+        ancestor, preserving causal connectivity.
+        """
+        kept_ids = {eid for eid, node in self._nodes.items() if predicate(node)}
+
+        new_nodes: dict[str, CausalNode] = {}
+        for eid in kept_ids:
+            node = self._nodes[eid]
+            # Find nearest ancestor that is also kept
+            new_parent_id: str | None = None
+            cursor = node.parent_id
+            while cursor is not None and cursor in self._nodes:
+                if cursor in kept_ids:
+                    new_parent_id = cursor
+                    break
+                cursor = self._nodes[cursor].parent_id
+
+            new_nodes[eid] = CausalNode(
+                event_id=node.event_id,
+                event_type=node.event_type,
+                time=node.time,
+                parent_id=new_parent_id,
+            )
+
+        return CausalGraph(new_nodes)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation with summary stats."""
+        return {
+            "nodes": [node.to_dict() for node in self._nodes.values()],
+            "stats": {
+                "total_nodes": len(self._nodes),
+                "roots": len(self._root_ids),
+                "leaves": len(self.leaves()),
+                "max_depth": max(
+                    (self.depth(eid) for eid in self._nodes), default=0
+                ),
+                "critical_path_length": len(self.critical_path()),
+            },
+        }
+
+
+def build_causal_graph(
+    recorder: InMemoryTraceRecorder,
+    *,
+    exclude_event_types: set[str] | None = None,
+) -> CausalGraph:
+    """Build a CausalGraph from an InMemoryTraceRecorder.
+
+    Reads ``simulation.schedule`` spans which contain ``event_id``,
+    ``event_type``, ``scheduled_time``, and ``parent_id``.
+    Deduplicates by event_id (ProcessContinuation shares ID with parent
+    event since they share the same context dict).
+
+    Args:
+        recorder: The trace recorder from a completed simulation.
+        exclude_event_types: Event types to omit from the graph.
+
+    Returns:
+        A CausalGraph with one node per unique scheduled event.
+    """
+    exclude = exclude_event_types or set()
+    nodes: dict[str, CausalNode] = {}
+
+    for span in recorder.spans:
+        if span["kind"] != "simulation.schedule":
+            continue
+
+        event_id = span.get("event_id")
+        event_type = span.get("event_type")
+        if event_id is None or event_type is None:
+            continue
+
+        if event_type in exclude:
+            continue
+
+        # Deduplicate: first occurrence wins (ProcessContinuation reuses ID)
+        if event_id in nodes:
+            continue
+
+        data = span.get("data", {})
+        scheduled_time = data.get("scheduled_time") or span.get("time")
+        parent_id = data.get("parent_id")
+
+        nodes[event_id] = CausalNode(
+            event_id=event_id,
+            event_type=event_type,
+            time=scheduled_time,
+            parent_id=parent_id,
+        )
+
+    return CausalGraph(nodes)

--- a/tests/integration/test_causal_graph_integration.py
+++ b/tests/integration/test_causal_graph_integration.py
@@ -1,0 +1,328 @@
+"""Integration tests for CausalGraph with real simulations."""
+
+from typing import Generator
+
+import pytest
+
+from happysimulator.core.entity import Entity
+from happysimulator.core.event import Event
+from happysimulator.core.temporal import Instant
+from happysimulator.core.simulation import Simulation
+from happysimulator.components.common import Counter, Sink
+from happysimulator.load.source import Source
+from happysimulator.instrumentation.recorder import InMemoryTraceRecorder, NullTraceRecorder
+from happysimulator.analysis.causal_graph import build_causal_graph, CausalGraph
+
+
+# ---------------------------------------------------------------------------
+# Helper entities
+# ---------------------------------------------------------------------------
+
+class ForwardingServer(Entity):
+    """Simple server that forwards events downstream after a delay."""
+
+    def __init__(self, name: str, downstream: Entity, delay: float = 0.1):
+        super().__init__(name)
+        self.downstream = downstream
+        self._delay = delay
+        self.processed = 0
+
+    def handle_event(self, event: Event) -> Generator[float, None, list[Event]]:
+        yield self._delay
+        self.processed += 1
+        return [Event(
+            time=self.now,
+            event_type="Forwarded",
+            target=self.downstream,
+            context={"created_at": event.context.get("created_at", self.now)},
+        )]
+
+
+class SideEffectServer(Entity):
+    """Server that emits a side-effect event mid-generator."""
+
+    def __init__(self, name: str, downstream: Entity, side_target: Entity):
+        super().__init__(name)
+        self.downstream = downstream
+        self.side_target = side_target
+
+    def handle_event(self, event: Event) -> Generator:
+        # Emit side-effect event during yield
+        yield 0.05, [Event(
+            time=self.now,
+            event_type="SideEffect",
+            target=self.side_target,
+        )]
+        yield 0.05
+        return [Event(
+            time=self.now,
+            event_type="Done",
+            target=self.downstream,
+        )]
+
+
+# ---------------------------------------------------------------------------
+# Source → Server → Sink causal chain
+# ---------------------------------------------------------------------------
+
+class TestSourceServerSinkChain:
+    def test_causal_chain_exists(self):
+        """Events produced by Source→Server→Sink form a causal chain."""
+        recorder = InMemoryTraceRecorder()
+        sink = Counter("Sink")
+        server = ForwardingServer("Server", downstream=sink)
+        source = Source.constant(rate=10, target=server, event_type="Request", stop_after=1.0)
+
+        sim = Simulation(
+            end_time=Instant.from_seconds(5.0),
+            sources=[source],
+            entities=[server, sink],
+            trace_recorder=recorder,
+        )
+        sim.run()
+
+        graph = build_causal_graph(recorder)
+        assert len(graph) > 0
+
+        # There should be root events (from source, no parent)
+        roots = graph.roots()
+        assert len(roots) > 0
+
+        # There should be Forwarded events that are children of something
+        forwarded = [n for n in graph.nodes.values() if n.event_type == "Forwarded"]
+        assert len(forwarded) > 0
+        for fwd in forwarded:
+            assert fwd.parent_id is not None
+
+    def test_forwarded_events_have_server_as_parent(self):
+        """Forwarded events are caused by the Request events processing."""
+        recorder = InMemoryTraceRecorder()
+        sink = Counter("Sink")
+        server = ForwardingServer("Server", downstream=sink)
+        source = Source.constant(rate=2, target=server, event_type="Request", stop_after=1.0)
+
+        sim = Simulation(
+            end_time=Instant.from_seconds(5.0),
+            sources=[source],
+            entities=[server, sink],
+            trace_recorder=recorder,
+        )
+        sim.run()
+
+        graph = build_causal_graph(recorder)
+
+        forwarded = [n for n in graph.nodes.values() if n.event_type == "Forwarded"]
+        for fwd in forwarded:
+            # Walk up ancestors — should eventually reach a Request event
+            ancestors = graph.ancestors(fwd.event_id)
+            ancestor_types = {a.event_type for a in ancestors}
+            assert "Request" in ancestor_types, (
+                f"Forwarded event {fwd.event_id} has no Request ancestor. "
+                f"Ancestors: {ancestor_types}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Generator side-effect events have correct parent
+# ---------------------------------------------------------------------------
+
+class TestGeneratorSideEffects:
+    def test_side_effect_parent_is_processing_event(self):
+        """Side-effect events emitted during yield should have the
+        processing event as parent."""
+        recorder = InMemoryTraceRecorder()
+        side_counter = Counter("SideCounter")
+        done_counter = Counter("DoneCounter")
+        server = SideEffectServer("Server", downstream=done_counter, side_target=side_counter)
+
+        # Schedule a single event directly
+        sim = Simulation(
+            end_time=Instant.from_seconds(2.0),
+            entities=[server, side_counter, done_counter],
+            trace_recorder=recorder,
+        )
+        sim.schedule(Event(
+            time=Instant.from_seconds(0.1),
+            event_type="Trigger",
+            target=server,
+        ))
+        sim.run()
+
+        assert side_counter.total >= 1
+        assert done_counter.total >= 1
+
+        graph = build_causal_graph(recorder)
+
+        side_effects = [n for n in graph.nodes.values() if n.event_type == "SideEffect"]
+        assert len(side_effects) >= 1
+
+        for se in side_effects:
+            # Side-effect should trace back to the Trigger event
+            ancestors = graph.ancestors(se.event_id)
+            ancestor_types = {a.event_type for a in ancestors}
+            assert "Trigger" in ancestor_types
+
+
+# ---------------------------------------------------------------------------
+# sim.causal_graph() convenience method
+# ---------------------------------------------------------------------------
+
+class TestSimCausalGraphConvenience:
+    def test_with_recorder(self):
+        """sim.causal_graph() works with InMemoryTraceRecorder."""
+        recorder = InMemoryTraceRecorder()
+        counter = Counter("Sink")
+        source = Source.constant(rate=5, target=counter, event_type="Ping", stop_after=1.0)
+
+        sim = Simulation(
+            end_time=Instant.from_seconds(5.0),
+            sources=[source],
+            entities=[counter],
+            trace_recorder=recorder,
+        )
+        sim.run()
+
+        graph = sim.causal_graph()
+        assert isinstance(graph, CausalGraph)
+        assert len(graph) > 0
+
+    def test_without_recorder_raises(self):
+        """sim.causal_graph() raises TypeError without InMemoryTraceRecorder."""
+        counter = Counter("Sink")
+        source = Source.constant(rate=5, target=counter, event_type="Ping", stop_after=1.0)
+
+        sim = Simulation(
+            end_time=Instant.from_seconds(5.0),
+            sources=[source],
+            entities=[counter],
+        )
+        sim.run()
+
+        with pytest.raises(TypeError, match="InMemoryTraceRecorder"):
+            sim.causal_graph()
+
+    def test_with_null_recorder_raises(self):
+        """Explicit NullTraceRecorder also raises."""
+        counter = Counter("Sink")
+        sim = Simulation(
+            end_time=Instant.from_seconds(1.0),
+            entities=[counter],
+            trace_recorder=NullTraceRecorder(),
+        )
+        sim.run()
+
+        with pytest.raises(TypeError, match="NullTraceRecorder"):
+            sim.causal_graph()
+
+    def test_exclude_event_types(self):
+        """sim.causal_graph(exclude_event_types=...) passes through."""
+        recorder = InMemoryTraceRecorder()
+        counter = Counter("Sink")
+        source = Source.constant(rate=5, target=counter, event_type="Ping", stop_after=1.0)
+
+        sim = Simulation(
+            end_time=Instant.from_seconds(5.0),
+            sources=[source],
+            entities=[counter],
+            trace_recorder=recorder,
+        )
+        sim.run()
+
+        full_graph = sim.causal_graph()
+        filtered_graph = sim.causal_graph(exclude_event_types={"Ping"})
+
+        # Filtered graph should have fewer nodes
+        ping_count = sum(1 for n in full_graph.nodes.values() if n.event_type == "Ping")
+        assert len(filtered_graph) == len(full_graph) - ping_count
+
+
+# ---------------------------------------------------------------------------
+# Multiple sources → independent root families
+# ---------------------------------------------------------------------------
+
+class TestMultipleSources:
+    def test_independent_sources_create_separate_roots(self):
+        """Two independent sources produce events with no shared ancestry."""
+        recorder = InMemoryTraceRecorder()
+        counter_a = Counter("SinkA")
+        counter_b = Counter("SinkB")
+        source_a = Source.constant(rate=5, target=counter_a, event_type="PingA", stop_after=1.0)
+        source_b = Source.constant(rate=5, target=counter_b, event_type="PingB", stop_after=1.0)
+
+        sim = Simulation(
+            end_time=Instant.from_seconds(5.0),
+            sources=[source_a, source_b],
+            entities=[counter_a, counter_b],
+            trace_recorder=recorder,
+        )
+        sim.run()
+
+        graph = sim.causal_graph()
+
+        # Should have multiple roots
+        roots = graph.roots()
+        assert len(roots) >= 2
+
+        # PingA events should not share ancestry with PingB events
+        ping_a_nodes = [n for n in graph.nodes.values() if n.event_type == "PingA"]
+        ping_b_nodes = [n for n in graph.nodes.values() if n.event_type == "PingB"]
+
+        if ping_a_nodes and ping_b_nodes:
+            a_node = ping_a_nodes[0]
+            a_ancestor_ids = {a.event_id for a in graph.ancestors(a_node.event_id)}
+            a_ancestor_ids.add(a_node.event_id)
+
+            b_node = ping_b_nodes[0]
+            b_ancestor_ids = {b.event_id for b in graph.ancestors(b_node.event_id)}
+            b_ancestor_ids.add(b_node.event_id)
+
+            # No overlap between the two families
+            assert a_ancestor_ids.isdisjoint(b_ancestor_ids)
+
+
+# ---------------------------------------------------------------------------
+# QueuedResource internal events + filtering
+# ---------------------------------------------------------------------------
+
+class TestQueuedResourceFiltering:
+    def test_filter_internal_events(self):
+        """Can filter out internal event types from QueuedResource."""
+        from happysimulator.components.queued_resource import QueuedResource
+        from happysimulator.components.queue import FIFOQueue
+
+        class SimpleServer(QueuedResource):
+            def __init__(self, name, downstream):
+                super().__init__(name, policy=FIFOQueue())
+                self.downstream = downstream
+
+            def handle_queued_event(self, event):
+                yield 0.1
+                return [Event(
+                    time=self.now,
+                    event_type="Done",
+                    target=self.downstream,
+                )]
+
+        recorder = InMemoryTraceRecorder()
+        sink = Counter("Sink")
+        server = SimpleServer("Server", downstream=sink)
+        source = Source.constant(rate=5, target=server, event_type="Job", stop_after=1.0)
+
+        sim = Simulation(
+            end_time=Instant.from_seconds(5.0),
+            sources=[source],
+            entities=[server, sink],
+            trace_recorder=recorder,
+        )
+        sim.run()
+
+        full = sim.causal_graph()
+        # Filter to only Job and Done events
+        filtered = full.filter(lambda n: n.event_type in ("Job", "Done"))
+
+        # Filtered should be smaller
+        assert len(filtered) <= len(full)
+
+        # All remaining nodes should be Job or Done
+        for node in filtered.nodes.values():
+            assert node.event_type in ("Job", "Done")

--- a/tests/unit/test_causal_graph.py
+++ b/tests/unit/test_causal_graph.py
@@ -1,0 +1,330 @@
+"""Unit tests for the CausalGraph and build_causal_graph."""
+
+import pytest
+
+from happysimulator.core.temporal import Instant
+from happysimulator.instrumentation.recorder import InMemoryTraceRecorder
+from happysimulator.analysis.causal_graph import (
+    CausalGraph,
+    CausalNode,
+    build_causal_graph,
+)
+
+
+# ---------------------------------------------------------------------------
+# CausalNode
+# ---------------------------------------------------------------------------
+
+class TestCausalNode:
+    def test_to_dict(self):
+        node = CausalNode(
+            event_id="abc",
+            event_type="Request",
+            time=Instant.from_seconds(1.5),
+            parent_id="parent-1",
+        )
+        d = node.to_dict()
+        assert d["event_id"] == "abc"
+        assert d["event_type"] == "Request"
+        assert d["time_s"] == pytest.approx(1.5)
+        assert d["parent_id"] == "parent-1"
+
+    def test_to_dict_root(self):
+        node = CausalNode("r", "Init", Instant.Epoch, None)
+        assert node.to_dict()["parent_id"] is None
+
+    def test_frozen(self):
+        node = CausalNode("a", "X", Instant.Epoch, None)
+        with pytest.raises(AttributeError):
+            node.event_id = "b"
+
+
+# ---------------------------------------------------------------------------
+# CausalGraph — empty / single
+# ---------------------------------------------------------------------------
+
+class TestCausalGraphBasic:
+    def test_empty_graph(self):
+        g = CausalGraph({})
+        assert len(g) == 0
+        assert g.roots() == []
+        assert g.leaves() == []
+        assert g.critical_path() == []
+        assert "x" not in g
+
+    def test_single_root(self):
+        n = CausalNode("a", "Start", Instant.Epoch, None)
+        g = CausalGraph({"a": n})
+
+        assert len(g) == 1
+        assert "a" in g
+        assert g.roots() == [n]
+        assert g.leaves() == [n]
+        assert g.parent("a") is None
+        assert g.children("a") == []
+        assert g.ancestors("a") == []
+        assert g.descendants("a") == []
+        assert g.depth("a") == 0
+        assert g.critical_path() == [n]
+
+
+# ---------------------------------------------------------------------------
+# CausalGraph — linear chain A → B → C
+# ---------------------------------------------------------------------------
+
+class TestCausalGraphLinearChain:
+    @pytest.fixture
+    def chain_graph(self):
+        a = CausalNode("a", "Start", Instant.from_seconds(0), None)
+        b = CausalNode("b", "Mid", Instant.from_seconds(1), "a")
+        c = CausalNode("c", "End", Instant.from_seconds(2), "b")
+        return CausalGraph({"a": a, "b": b, "c": c})
+
+    def test_roots(self, chain_graph):
+        roots = chain_graph.roots()
+        assert len(roots) == 1
+        assert roots[0].event_id == "a"
+
+    def test_leaves(self, chain_graph):
+        leaves = chain_graph.leaves()
+        assert len(leaves) == 1
+        assert leaves[0].event_id == "c"
+
+    def test_parent(self, chain_graph):
+        assert chain_graph.parent("c").event_id == "b"
+        assert chain_graph.parent("b").event_id == "a"
+        assert chain_graph.parent("a") is None
+
+    def test_children(self, chain_graph):
+        assert [n.event_id for n in chain_graph.children("a")] == ["b"]
+        assert [n.event_id for n in chain_graph.children("b")] == ["c"]
+        assert chain_graph.children("c") == []
+
+    def test_ancestors(self, chain_graph):
+        anc = chain_graph.ancestors("c")
+        assert [n.event_id for n in anc] == ["b", "a"]
+
+    def test_descendants(self, chain_graph):
+        desc = chain_graph.descendants("a")
+        assert [n.event_id for n in desc] == ["b", "c"]
+
+    def test_depth(self, chain_graph):
+        assert chain_graph.depth("a") == 0
+        assert chain_graph.depth("b") == 1
+        assert chain_graph.depth("c") == 2
+
+    def test_critical_path(self, chain_graph):
+        path = chain_graph.critical_path()
+        assert [n.event_id for n in path] == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# CausalGraph — tree: A → {B, C}
+# ---------------------------------------------------------------------------
+
+class TestCausalGraphTree:
+    @pytest.fixture
+    def tree_graph(self):
+        a = CausalNode("a", "Root", Instant.from_seconds(0), None)
+        b = CausalNode("b", "Left", Instant.from_seconds(1), "a")
+        c = CausalNode("c", "Right", Instant.from_seconds(1), "a")
+        return CausalGraph({"a": a, "b": b, "c": c})
+
+    def test_roots_and_leaves(self, tree_graph):
+        assert len(tree_graph.roots()) == 1
+        assert len(tree_graph.leaves()) == 2
+
+    def test_children_of_root(self, tree_graph):
+        children = tree_graph.children("a")
+        assert {n.event_id for n in children} == {"b", "c"}
+
+    def test_depth(self, tree_graph):
+        assert tree_graph.depth("a") == 0
+        assert tree_graph.depth("b") == 1
+        assert tree_graph.depth("c") == 1
+
+
+# ---------------------------------------------------------------------------
+# Multiple roots
+# ---------------------------------------------------------------------------
+
+class TestCausalGraphMultipleRoots:
+    def test_independent_families(self):
+        r1 = CausalNode("r1", "Root1", Instant.from_seconds(0), None)
+        c1 = CausalNode("c1", "Child1", Instant.from_seconds(1), "r1")
+        r2 = CausalNode("r2", "Root2", Instant.from_seconds(0.5), None)
+        c2 = CausalNode("c2", "Child2", Instant.from_seconds(1.5), "r2")
+
+        g = CausalGraph({"r1": r1, "c1": c1, "r2": r2, "c2": c2})
+
+        roots = g.roots()
+        assert len(roots) == 2
+        # Sorted by time
+        assert roots[0].event_id == "r1"
+        assert roots[1].event_id == "r2"
+
+        assert g.descendants("r1") == [g.nodes["c1"]]
+        assert g.descendants("r2") == [g.nodes["c2"]]
+
+
+# ---------------------------------------------------------------------------
+# Critical path selection
+# ---------------------------------------------------------------------------
+
+class TestCriticalPath:
+    def test_picks_longest_branch(self):
+        """A → B → C → D (depth 3) vs A → E (depth 1)."""
+        a = CausalNode("a", "A", Instant.from_seconds(0), None)
+        b = CausalNode("b", "B", Instant.from_seconds(1), "a")
+        c = CausalNode("c", "C", Instant.from_seconds(2), "b")
+        d = CausalNode("d", "D", Instant.from_seconds(3), "c")
+        e = CausalNode("e", "E", Instant.from_seconds(1), "a")
+
+        g = CausalGraph({"a": a, "b": b, "c": c, "d": d, "e": e})
+        path = g.critical_path()
+        assert [n.event_id for n in path] == ["a", "b", "c", "d"]
+
+
+# ---------------------------------------------------------------------------
+# filter() with parent re-linking
+# ---------------------------------------------------------------------------
+
+class TestCausalGraphFilter:
+    def test_filter_keeps_matching(self):
+        a = CausalNode("a", "Request", Instant.from_seconds(0), None)
+        b = CausalNode("b", "Internal", Instant.from_seconds(1), "a")
+        c = CausalNode("c", "Request", Instant.from_seconds(2), "b")
+
+        g = CausalGraph({"a": a, "b": b, "c": c})
+
+        # Keep only Request events
+        filtered = g.filter(lambda n: n.event_type == "Request")
+        assert len(filtered) == 2
+        assert "a" in filtered
+        assert "c" in filtered
+        assert "b" not in filtered
+
+    def test_filter_relinks_parents(self):
+        """A(Request) → B(Internal) → C(Request): C's parent re-links to A."""
+        a = CausalNode("a", "Request", Instant.from_seconds(0), None)
+        b = CausalNode("b", "Internal", Instant.from_seconds(1), "a")
+        c = CausalNode("c", "Request", Instant.from_seconds(2), "b")
+
+        g = CausalGraph({"a": a, "b": b, "c": c})
+        filtered = g.filter(lambda n: n.event_type == "Request")
+
+        # C should now point to A (skipping B)
+        assert filtered.parent("c").event_id == "a"
+        assert filtered.children("a")[0].event_id == "c"
+
+    def test_filter_root_stays_root(self):
+        """When the parent chain is fully excluded, node becomes root."""
+        a = CausalNode("a", "Internal", Instant.from_seconds(0), None)
+        b = CausalNode("b", "Request", Instant.from_seconds(1), "a")
+
+        g = CausalGraph({"a": a, "b": b})
+        filtered = g.filter(lambda n: n.event_type == "Request")
+
+        assert len(filtered) == 1
+        assert filtered.parent("b") is None
+        assert filtered.roots()[0].event_id == "b"
+
+
+# ---------------------------------------------------------------------------
+# build_causal_graph() from recorder spans
+# ---------------------------------------------------------------------------
+
+class TestBuildCausalGraph:
+    def _make_schedule_span(self, event_id, event_type, time_s, parent_id=None):
+        """Helper to create a simulation.schedule span dict."""
+        return {
+            "time": Instant.from_seconds(time_s),
+            "kind": "simulation.schedule",
+            "event_id": event_id,
+            "event_type": event_type,
+            "data": {
+                "scheduled_time": Instant.from_seconds(time_s),
+                "parent_id": parent_id,
+            },
+        }
+
+    def test_basic_build(self):
+        recorder = InMemoryTraceRecorder()
+        recorder.spans = [
+            self._make_schedule_span("a", "Request", 0.0),
+            self._make_schedule_span("b", "Response", 1.0, parent_id="a"),
+        ]
+
+        graph = build_causal_graph(recorder)
+        assert len(graph) == 2
+        assert graph.parent("b").event_id == "a"
+
+    def test_deduplication(self):
+        """ProcessContinuation reuses event_id; only first occurrence kept."""
+        recorder = InMemoryTraceRecorder()
+        recorder.spans = [
+            self._make_schedule_span("a", "Request", 0.0),
+            self._make_schedule_span("a", "Request", 0.1),  # duplicate
+        ]
+
+        graph = build_causal_graph(recorder)
+        assert len(graph) == 1
+
+    def test_exclude_event_types(self):
+        recorder = InMemoryTraceRecorder()
+        recorder.spans = [
+            self._make_schedule_span("a", "Request", 0.0),
+            self._make_schedule_span("b", "Probe", 0.5),
+            self._make_schedule_span("c", "Response", 1.0, parent_id="a"),
+        ]
+
+        graph = build_causal_graph(recorder, exclude_event_types={"Probe"})
+        assert len(graph) == 2
+        assert "b" not in graph
+
+    def test_ignores_non_schedule_spans(self):
+        recorder = InMemoryTraceRecorder()
+        recorder.spans = [
+            {
+                "time": Instant.Epoch,
+                "kind": "simulation.init",
+                "data": {"num_sources": 1},
+            },
+            self._make_schedule_span("a", "Request", 0.0),
+        ]
+
+        graph = build_causal_graph(recorder)
+        assert len(graph) == 1
+
+    def test_missing_event_id_skipped(self):
+        recorder = InMemoryTraceRecorder()
+        recorder.spans = [
+            {
+                "time": Instant.Epoch,
+                "kind": "simulation.schedule",
+                "event_type": "Orphan",
+            },
+        ]
+
+        graph = build_causal_graph(recorder)
+        assert len(graph) == 0
+
+
+# ---------------------------------------------------------------------------
+# to_dict()
+# ---------------------------------------------------------------------------
+
+class TestCausalGraphToDict:
+    def test_to_dict_stats(self):
+        a = CausalNode("a", "Root", Instant.from_seconds(0), None)
+        b = CausalNode("b", "Child", Instant.from_seconds(1), "a")
+
+        g = CausalGraph({"a": a, "b": b})
+        d = g.to_dict()
+
+        assert d["stats"]["total_nodes"] == 2
+        assert d["stats"]["roots"] == 1
+        assert d["stats"]["leaves"] == 1
+        assert d["stats"]["max_depth"] == 1
+        assert d["stats"]["critical_path_length"] == 2
+        assert len(d["nodes"]) == 2


### PR DESCRIPTION
## Summary
- Adds automatic parent-child relationship tracking between events during simulation via module-level `_current_processing_event_id` in `event.py`
- Introduces `CausalGraph` class with rich query API: `parent()`, `children()`, `ancestors()`, `descendants()`, `roots()`, `leaves()`, `depth()`, `critical_path()`, `filter()`, `to_dict()`
- Adds `build_causal_graph(recorder)` factory and `sim.causal_graph()` convenience method for post-simulation analysis

## Test plan
- [x] 27 unit tests covering CausalNode serialization, graph traversal, critical path, filter with parent re-linking, build from recorder spans, deduplication, and exclusion
- [x] 9 integration tests covering Source→Server→Sink chains, generator side-effects, QueuedResource filtering, convenience method, and multiple independent sources
- [x] Full regression suite passes (1755 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)