### PR TITLE
Add inductor burst suppression visual debugger example

### DIFF
--- a/.dev/inductor-visual-example-design.md
+++ b/.dev/inductor-visual-example-design.md
@@ -1,0 +1,70 @@
+# Inductor Burst Suppression — Visual Debugger Example
+
+## Context
+
+The Inductor is a novel component that smooths bursty traffic using EWMA rate estimation — unlike traditional rate limiters, it has **no throughput cap** and only resists rapid rate *changes*. The existing integration test (`tests/integration/test_inductor.py`) validates this behavior under multiple load profiles and generates static PNG plots. This example brings those same scenarios to the interactive browser-based visual debugger so users can step through and observe the inductor's behavior in real-time.
+
+## New File
+
+`examples/inductor_burst_suppression.py` (~90 lines)
+
+## Design
+
+### Pipeline
+
+```
+Source (LoadGenerator) → InputCounter → Inductor (τ=2s) → ThroughputTracker (OutputTracker)
+                                             ↑
+                                    Probe: estimated_rate
+                                    Probe: queue_depth
+```
+
+- **InputCounter** — Minimal passthrough entity (defined inline, ~10 lines). Records `1.0` per event to its own `Data` object, then forwards the event to the Inductor. Needed because `ThroughputTracker` is terminal (returns `[]`), so we can't use it as a passthrough.
+- **ThroughputTracker** — Existing collector from `happysimulator.instrumentation.collectors`. Serves as the downstream sink and records output throughput.
+
+### Multi-Phase Profile (`InductorShowcaseProfile`)
+
+A single `Profile` subclass with three demo phases separated by 10s cooldowns at base rate:
+
+| Time | Phase | Rate | What it demonstrates |
+|------|-------|------|---------------------|
+| 0–15s | Step-up (low) | 10 req/s | Baseline |
+| 15–40s | Step-up (high) | 50 req/s | Output slowly approaches 50; queue builds during transition |
+| 40–50s | Cooldown | 10 req/s | EWMA resets toward baseline |
+| 50–100s | Linear ramp | 10→50 req/s | Output tracks input with no limiting; queue stays near 0 |
+| 100–110s | Cooldown | 10 req/s | EWMA resets toward baseline |
+| 110–180s | Periodic bursts | 10/80 req/s (period=10s, burst=2s) | Full up/down dampening visible |
+
+Total simulation: **180s**. Uses `poisson=False` for deterministic arrivals (matching the integration tests).
+
+### Charts (4 total)
+
+| # | Title | Data Source | Transform | Color | Purpose |
+|---|-------|------------|-----------|-------|---------|
+| 1 | Input Throughput | `InputCounter.data` | `rate`, window=1s | `#6366f1` (indigo) | Raw input rate — what the load generator produces |
+| 2 | Output Throughput | `ThroughputTracker.data` | `rate`, window=1s | `#10b981` (emerald) | Smoothed output — what passes through the inductor |
+| 3 | EWMA Rate Estimate | Probe `estimated_rate` | `raw` | `#f59e0b` (amber) | The inductor's internal rate model |
+| 4 | Queue Depth | Probe `queue_depth` | `raw` | `#ef4444` (red) | Buffering during rate suppression |
+
+Both probes sample at 0.1s intervals.
+
+### Key Parameters
+
+- `time_constant=2.0` — matches integration tests; provides visible smoothing without being overly aggressive (~6-8s full adaptation)
+- `queue_capacity=10_000` — default, more than sufficient for this demo
+
+## Files to Reference
+
+- `examples/visual_debugger.py` — pattern for inline entities, serve() call, Chart wiring
+- `happysimulator/components/rate_limiter/inductor.py` — `estimated_rate`, `queue_depth` properties
+- `happysimulator/instrumentation/collectors.py` — `ThroughputTracker`
+- `happysimulator/visual/dashboard.py` — `Chart` API and transforms
+
+## Verification
+
+1. Run `python examples/inductor_burst_suppression.py`
+2. Browser opens at `http://127.0.0.1:8765`
+3. Click "Play" and observe all 4 charts updating through the three phases
+4. Verify Phase 1: Input jumps to 50, output rises slowly, queue spikes
+5. Verify Phase 2: Input ramps linearly, output tracks closely, queue near 0
+6. Verify Phase 3: Input oscillates 10/80, output dampened, queue pulses

--- a/examples/inductor_burst_suppression.py
+++ b/examples/inductor_burst_suppression.py
@@ -1,0 +1,129 @@
+"""Inductor burst suppression — visual debugger example.
+
+Demonstrates the Inductor's EWMA-based smoothing across three traffic
+patterns: step-up, linear ramp, and periodic bursts.  Unlike a rate
+limiter the Inductor has **no throughput cap** — it only resists rapid
+rate *changes*.
+
+Launch with:
+    python examples/inductor_burst_suppression.py
+
+Opens a browser at http://127.0.0.1:8765 with four charts showing
+input/output throughput, EWMA rate estimate, and queue depth.
+"""
+
+from dataclasses import dataclass
+
+from happysimulator.core.entity import Entity
+from happysimulator.core.event import Event
+from happysimulator.core.simulation import Simulation
+from happysimulator.core.temporal import Instant
+from happysimulator.components.rate_limiter.inductor import Inductor
+from happysimulator.instrumentation.collectors import ThroughputTracker
+from happysimulator.instrumentation.data import Data
+from happysimulator.instrumentation.probe import Probe
+from happysimulator.load.profile import Profile
+from happysimulator.load.source import Source
+from happysimulator.visual import serve, Chart
+
+
+# -- Inline passthrough counter -----------------------------------------------
+
+class InputCounter(Entity):
+    """Counts arrivals (1.0 per event) then forwards to downstream."""
+
+    def __init__(self, name: str, downstream: Entity) -> None:
+        super().__init__(name)
+        self.data = Data()
+        self._downstream = downstream
+
+    def handle_event(self, event: Event) -> list[Event]:
+        self.data.add_stat(1.0, event.time)
+        return [Event(
+            time=event.time,
+            event_type=event.event_type,
+            target=self._downstream,
+            context=event.context,
+        )]
+
+
+# -- Multi-phase profile ------------------------------------------------------
+
+@dataclass(frozen=True)
+class InductorShowcaseProfile(Profile):
+    """Three demo phases separated by cooldown periods at base rate.
+
+    Phase 1 (0–40s):   Step-up from 10 to 50 req/s at t=15s
+    Cooldown (40–50s):  10 req/s
+    Phase 2 (50–100s):  Linear ramp 10→50 req/s
+    Cooldown (100–110s): 10 req/s
+    Phase 3 (110–180s): Periodic bursts (10/80 req/s, period=10s, burst=2s)
+    """
+
+    base_rate: float = 10.0
+
+    def get_rate(self, time: Instant) -> float:
+        t = time.to_seconds()
+
+        # Phase 1: step-up
+        if t < 15.0:
+            return self.base_rate
+        if t < 40.0:
+            return 50.0
+
+        # Cooldown
+        if t < 50.0:
+            return self.base_rate
+
+        # Phase 2: linear ramp 10→50 over 50s
+        if t < 100.0:
+            fraction = (t - 50.0) / 50.0
+            return self.base_rate + fraction * (50.0 - self.base_rate)
+
+        # Cooldown
+        if t < 110.0:
+            return self.base_rate
+
+        # Phase 3: periodic bursts (period=10s, burst first 2s at 80, rest at 10)
+        t_in_cycle = (t - 110.0) % 10.0
+        return 80.0 if t_in_cycle < 2.0 else self.base_rate
+
+
+# -- Wiring --------------------------------------------------------------------
+
+output_tracker = ThroughputTracker("OutputTracker")
+inductor = Inductor("Inductor", downstream=output_tracker, time_constant=2.0)
+input_counter = InputCounter("InputCounter", downstream=inductor)
+
+source = Source.with_profile(
+    profile=InductorShowcaseProfile(),
+    target=input_counter,
+    event_type="Request",
+    poisson=False,
+    name="LoadGenerator",
+)
+
+# Probes on inductor internals
+rate_data = Data()
+rate_probe = Probe(target=inductor, metric="estimated_rate", data=rate_data, interval=0.1)
+
+depth_data = Data()
+depth_probe = Probe(target=inductor, metric="queue_depth", data=depth_data, interval=0.1)
+
+sim = Simulation(
+    sources=[source],
+    entities=[input_counter, inductor, output_tracker],
+    probes=[rate_probe, depth_probe],
+    end_time=Instant.from_seconds(180.0),
+)
+
+serve(sim, charts=[
+    Chart(input_counter.data, title="Input Throughput",
+          transform="rate", window_s=1.0, y_label="req/s", color="#6366f1"),
+    Chart(output_tracker.data, title="Output Throughput",
+          transform="rate", window_s=1.0, y_label="req/s", color="#10b981"),
+    Chart(rate_data, title="EWMA Rate Estimate",
+          transform="raw", y_label="req/s", color="#f59e0b"),
+    Chart(depth_data, title="Queue Depth",
+          transform="raw", y_label="items", color="#ef4444"),
+])

--- a/happysimulator/components/__init__.py
+++ b/happysimulator/components/__init__.py
@@ -269,6 +269,7 @@ from happysimulator.components.microservice import (
     APIGateway,
     APIGatewayStats,
     RouteConfig,
+)
 from happysimulator.components.infrastructure import (
     DiskIO,
     DiskIOStats,


### PR DESCRIPTION
## Summary

- Add `examples/inductor_burst_suppression.py` — interactive browser-based visual debugger example showcasing the Inductor's EWMA burst suppression across three traffic patterns (step-up, linear ramp, periodic bursts) with four live charts (input/output throughput, EWMA rate estimate, queue depth)
- Add `.dev/inductor-visual-example-design.md` design document
- Fix missing closing `)` in `happysimulator/components/__init__.py` (microservice import block)

## Test plan

- [ ] Run `python examples/inductor_burst_suppression.py` and verify browser opens at `http://127.0.0.1:8765`
- [ ] Click "Play" and observe all 4 charts updating through the three phases
- [ ] Phase 1: Input jumps to 50, output rises slowly, queue spikes
- [ ] Phase 2: Input ramps linearly, output tracks closely, queue near 0
- [ ] Phase 3: Input oscillates 10/80, output dampened, queue pulses
- [ ] Run `pytest -q` and verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)