### PR TITLE
Add breakpoint management UI to visual debugger

### DIFF
--- a/.claude/skills/visual-debugger/SKILL.md
+++ b/.claude/skills/visual-debugger/SKILL.md
@@ -15,6 +15,16 @@ Launch the browser-based simulation debugger at http://127.0.0.1:8765.
 3. Tell the user the server is running at http://127.0.0.1:8765
 4. Remind them to press Ctrl+C in the terminal to stop the server when done
 
+## Rebuild After Frontend Changes
+
+After modifying any file under `visual-frontend/src/`, always rebuild so the static assets served by the Python backend are up to date:
+
+```bash
+cd visual-frontend && npm run build
+```
+
+This runs `tsc -b && vite build`, outputting to `happysimulator/visual/static/`. The built assets (hashed `.js` and `.css` files) should be committed alongside the source changes.
+
 ## Clean Build & Reset
 
 If the debugger is showing stale UI that doesn't reflect recent frontend changes, do a full clean rebuild:


### PR DESCRIPTION
## Summary

- Add REST API endpoints (`GET/POST/DELETE /api/breakpoints`) for full breakpoint CRUD from the browser
- Enrich `breakpoint_hit` WebSocket message with current breakpoint list so the UI stays in sync
- Add `BreakpointPanel` component with a table of active breakpoints (type badge, description, one-shot, delete) and an add form supporting Time, Event Count, Event Type, and Metric breakpoint types
- Add "BP" button with purple badge count in the control bar to toggle the panel
- Wire time-based breakpoints to the Timeline component as diamond markers

## Test plan

- [x] `pytest tests/unit/ -q` — all pass, no regressions
- [x] `npx tsc --noEmit` — TypeScript compiles clean
- [x] `npm run build` — Vite build succeeds
- [ ] Manual: run `python examples/visual_debugger.py`, click BP button, add a TimeBreakpoint at t=5.0, hit Debug, verify pause at ~5.0s
- [ ] Verify diamond appears on timeline for time breakpoints
- [ ] Delete a breakpoint, verify it disappears from table and timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)