### PR TITLE
Rewrite README with features, quick start, and banner placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,107 @@
-# happy-simulator
+<p align="center">
+  <!-- Replace with project banner/logo (recommended: 1200x400px) -->
+  <img src="docs/assets/banner-placeholder.png" alt="happy-simulator" width="100%" />
+</p>
 
-[![PyPI](https://img.shields.io/pypi/v/happysim)](https://pypi.org/project/happysim/)
-[![Tests](https://github.com/adamfilli/happy-simulator/actions/workflows/tests.yml/badge.svg)](https://github.com/adamfilli/happy-simulator/actions/workflows/tests.yml)
-[![Docs](https://github.com/adamfilli/happy-simulator/actions/workflows/docs.yml/badge.svg)](https://adamfilli.github.io/happy-simulator/)
+<h1 align="center">happy-simulator</h1>
 
-**** ALPHA ** Still in active development, large changes are expected.
+<p align="center">
+  <strong>A discrete-event simulation library for Python 3.13+</strong>
+</p>
 
-A discrete-event simulation library with a focus on distributed systems.
+<p align="center">
+  <a href="https://pypi.org/project/happysim/"><img src="https://img.shields.io/pypi/v/happysim" alt="PyPI" /></a>
+  <a href="https://github.com/adamfilli/happy-simulator/actions/workflows/tests.yml"><img src="https://github.com/adamfilli/happy-simulator/actions/workflows/tests.yml/badge.svg" alt="Tests" /></a>
+  <a href="https://adamfilli.github.io/happy-simulator/"><img src="https://github.com/adamfilli/happy-simulator/actions/workflows/docs.yml/badge.svg" alt="Docs" /></a>
+  <a href="https://github.com/adamfilli/happy-simulator/blob/main/license"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
+</p>
 
-https://adamfillion.com/posts/simulation-enhanced-reasoning/
+<p align="center">
+  <a href="https://adamfilli.github.io/happy-simulator/">Documentation</a> &middot;
+  <a href="https://adamfilli.github.io/happy-simulator/examples/">Examples</a> &middot;
+  <a href="https://adamfillion.com/posts/simulation-enhanced-reasoning/">Blog Post</a>
+</p>
+
+---
+
+> **Alpha** — Still in active development. APIs may change between releases.
+
+happy-simulator is a composable, generator-based discrete-event simulation engine built for modeling queuing systems, distributed systems, manufacturing lines, and human behavior. It ships with 70+ ready-to-run examples and a browser-based visual debugger.
+
+## Features
+
+- **Generator-driven entities** — model delays and async coordination with `yield`
+- **Rich component library** — queues, load balancers, rate limiters, circuit breakers, consensus protocols, industrial components, and more
+- **Network simulation** — topology, latency models, partitions, and per-node clock skew/drift
+- **Behavioral modeling** — agents with personality traits, decision models, social graphs, and influence propagation
+- **Observability built in** — probes, latency/throughput trackers, bucketed time series
+- **Simulation control** — pause, step, breakpoints (time, event count, metric threshold, conditional)
+- **Visual debugger** — browser-based UI with entity graph, live dashboards, event log, and step-through debugging
+
+## Quick Start
+
+```bash
+pip install happysim
+```
+
+```python
+from happysimulator import Simulation, Source, Sink, Event, Instant
+from happysimulator.components.queued_resource import QueuedResource
+from happysimulator.components.queue_policies import FIFOQueue
+
+class Server(QueuedResource):
+    def __init__(self, downstream):
+        super().__init__("Server", policy=FIFOQueue())
+        self.downstream = downstream
+
+    def handle_queued_event(self, event):
+        yield 0.1  # process for 100ms
+        return [Event(time=self.now, event_type="Done", target=self.downstream)]
+
+sink = Sink()
+server = Server(downstream=sink)
+source = Source.poisson(rate=8, target=server)
+
+sim = Simulation(entities=[source, server, sink], end_time=Instant.from_seconds(60))
+summary = sim.run()
+
+print(f"Processed {summary.total_events_processed} events in {summary.wall_clock_seconds:.2f}s")
+print(f"Latency: {sink.latency_stats()}")
+```
+
+## Visual Debugger
+
+```bash
+pip install happysim[visual]
+```
+
+```python
+from happysimulator.visual import serve
+serve(sim)  # opens browser at http://127.0.0.1:8765
+```
+
+Step through events, inspect entity state, pin live charts to the graph, and set breakpoints — all from the browser.
 
 ## Installation
 
 ```bash
-# Clone the repository
+pip install happysim              # core library
+pip install happysim[visual]      # + browser debugger (FastAPI + uvicorn)
+pip install happysim[dev]         # + testing & docs tools
+```
+
+Or install from source:
+
+```bash
 git clone https://github.com/adamfilli/happy-simulator.git
 cd happy-simulator
-
-# Create and activate a virtual environment (Windows PowerShell)
-python -m venv .venv
-.\.venv\Scripts\Activate.ps1
-
-# Install in development mode
-pip install -e .
-
-# Install with development dependencies
 pip install -e ".[dev]"
 ```
+
+## Documentation
+
+Full guides, API reference, and example walkthroughs at **[adamfilli.github.io/happy-simulator](https://adamfilli.github.io/happy-simulator/)**.
+
+## License
+
+[Apache 2.0](license)


### PR DESCRIPTION
## Summary

- Replace minimal README with a polished, centered-layout version
- Add banner/logo image placeholder (1200x400px recommended)
- Add centered badge row (PyPI, Tests, Docs, License) and nav links
- Add feature highlights, quick start code example, visual debugger section
- Add pip install options (core, visual, dev) and from-source instructions
- Link to docs site and license

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify all badge links and nav links work
- [ ] Verify code example is syntactically correct