### PR TITLE
Expand ruff linter rules and formatting config

### DIFF
--- a/.claude/skills/ruff/SKILL.md
+++ b/.claude/skills/ruff/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: ruff
+description: Run ruff linter and formatter on the project
+disable-model-invocation: true
+---
+
+# Ruff
+
+Run the ruff linter and/or formatter on the project. Configuration is in `pyproject.toml` under `[tool.ruff]`.
+
+## Instructions
+
+1. Determine what the user wants:
+   - **No arguments or "check"**: lint check only
+   - **"fix"**: lint with auto-fix
+   - **"format"**: format code
+   - **"all"**: lint fix + format (the full cleanup)
+   - **A specific path**: scope to that path
+
+2. Run the appropriate commands using `.venv/Scripts/python.exe -m ruff`:
+   - Lint check: `.venv/Scripts/python.exe -m ruff check .`
+   - Lint fix: `.venv/Scripts/python.exe -m ruff check --fix .`
+   - Format check: `.venv/Scripts/python.exe -m ruff format --check .`
+   - Format apply: `.venv/Scripts/python.exe -m ruff format .`
+   - Full cleanup: `.venv/Scripts/python.exe -m ruff check --fix . && .venv/Scripts/python.exe -m ruff format .`
+
+3. If a specific path is provided, replace `.` with that path in all commands.
+
+4. Report the results:
+   - Number of violations found
+   - Number of auto-fixed violations (if --fix was used)
+   - Number of files reformatted (if format was used)
+   - List any remaining violations that require manual attention
+
+5. Do NOT auto-fix violations unless the user asks for "fix", "all", or explicitly requests fixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,32 @@ select = [
     "UP",     # pyupgrade
     "B",      # flake8-bugbear
     "SIM",    # flake8-simplify
+    "N",      # pep8-naming
+    "C4",     # flake8-comprehensions
+    "PTH",    # flake8-use-pathlib
+    "RUF",    # Ruff-specific rules
+    "PIE",    # flake8-pie (misc. lints)
+    "T20",    # flake8-print (flag print statements in library code)
+    "RET",    # flake8-return
+    "TCH",    # flake8-type-checking (move imports behind TYPE_CHECKING)
+    "PGH",    # pygrep-hooks
+    "PERF",   # Perflint (performance anti-patterns)
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)
+    "RET504", # unnecessary assignment before return
+    "SIM108", # use ternary instead of if-else (readability preference)
+    "N806",   # variable in function should be lowercase (conflicts with math conventions)
+    "UP007",  # use X | Y for union types (keep Optional for readability in some cases)
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"examples/**" = ["T20"]   # allow print() in examples
+"tests/**" = ["T20"]      # allow print() in tests
 
 [tool.ruff.lint.isort]
 known-first-party = ["happysimulator"]
+
+[tool.ruff.format]
+quote-style = "double"
+docstring-code-format = true


### PR DESCRIPTION
## Summary
- Add 9 new ruff rule sets: naming (`N`), comprehensions (`C4`), pathlib (`PTH`), ruff-specific (`RUF`), pie (`PIE`), print-detection (`T20`), return (`RET`), type-checking (`TCH`), pygrep-hooks (`PGH`), and perflint (`PERF`)
- Configure targeted ignores (`RET504`, `SIM108`, `N806`, `UP007`) to avoid false positives
- Add per-file ignores to allow `print()` in examples and tests
- Enable `docstring-code-format` and set `quote-style = "double"` in ruff formatter config
- Add ruff skill for Claude Code

## Test plan
- [ ] Run `ruff check .` to verify no new violations surface unexpectedly
- [ ] Run `ruff format --check .` to confirm formatting config is valid
- [ ] Run `pytest -q` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)