### PR TITLE
Optimize core engine for 2.65x throughput improvement

### DIFF
--- a/.dev/performance-optimization-design.md
+++ b/.dev/performance-optimization-design.md
@@ -1,0 +1,185 @@
+# Performance Audit & Optimization Plan — happysimulator Core Engine
+
+## Context
+
+The simulation core runs at **~50K events/sec** (Python 3.14). Profiling the `throughput` benchmark (0.2x scale, 54.3s) reveals that **~40% of CPU time** is spent on overhead unrelated to actual simulation logic: UUID generation (7.2%), application-level tracing (2.9%), dict lookups for trace context (5.8%), and run-loop branching/attribute lookups (17.7%). Memory is also bloated: 745 bytes/event, with `Instant` objects using 128 bytes each (vs 40 with `__slots__`).
+
+The goal is a **25-40% throughput improvement** and **30-50% memory reduction** through targeted optimizations, plus a parallelism utility for multi-run workloads.
+
+---
+
+## Profiling Summary
+
+| Hotspot | % of CPU | Root Cause |
+|---------|----------|------------|
+| `_run_loop` self-time | 17.7% | Attribute lookups, control checks, trace calls |
+| `uuid.uuid4()` + `str()` | 7.2% | Called for every Event incl. ProcessContinuations |
+| `dict.get()` (6.7M calls) | 5.8% | `context.get("id")` in trace.record() calls |
+| `Event.invoke()` | 7.1% | Unconditional trace/stack building |
+| `Event.__init__` | 6.6% | UUID + context setup + on_complete list |
+| `Event.trace()` (2.1M calls) | 2.9% | Dict alloc + append per call, never read |
+| `ProcessContinuation.__init__` | 3.7% | Calls full `Event.__init__`, wastes UUID |
+
+---
+
+## Implementation Plan
+
+### Step 1: Save pre-optimization baseline
+```bash
+python -m tests.perf --save-baseline --checkpoint
+```
+
+### Step 2: Add `__slots__` to Instant and Duration
+**File**: `happysimulator/core/temporal.py`
+
+Add `__slots__ = ('nanoseconds',)` to both `Duration` and `Instant`. Add `__slots__ = ()` to `_InfiniteInstant` (subclass, no new attrs).
+
+**Impact**: 128 → 40 bytes per Instant. Negligible speed change but significant memory reduction at scale.
+
+**Risk**: Very low. Verified no code does `instant.__dict__`.
+
+### Step 3: Replace UUID4 with integer counter for Event._id
+**File**: `happysimulator/core/event.py`
+
+- Remove `import uuid`
+- Change `self._id = uuid.uuid4()` → `self._id = self._sort_index` (reuse the existing global counter)
+- `context.setdefault("id", str(self._id))` remains — `str(int)` is 30x faster than `str(uuid4())`
+- `__hash__` and `__eq__` work unchanged with int
+
+**Consumers verified safe**: `visual/serializers.py:140` does `str(event._id)` (works with int). No tests reference `_id` as UUID. `context["id"]` remains a string.
+
+**Impact**: ~7-10% throughput improvement. uuid4+str is 800K ops/sec vs counter: 24M ops/sec.
+
+### Step 4: Guard NullTraceRecorder calls with boolean flag
+**Files**: `happysimulator/core/event_heap.py`, `happysimulator/core/simulation.py`
+
+Add `self._tracing_enabled = not isinstance(self._trace, NullTraceRecorder)` in both `EventHeap.__init__` and `Simulation.__init__`. Wrap all `self._trace.record(...)` calls with `if self._tracing_enabled:`.
+
+This eliminates:
+- kwargs dict construction for every `record()` call
+- `event.context.get("id")` lookups (5.8% of CPU) when tracing is off
+- 4 trace.record() calls per event in the hot loop
+
+**Impact**: ~3-5% throughput improvement.
+
+### Step 5: Cache frequently-accessed attributes as locals in _run_loop
+**File**: `happysimulator/core/simulation.py`
+
+At the top of `_run_loop`, cache as local variables:
+```python
+control = self._control
+heap = self._event_heap
+end_time = self._end_time
+clock = self._clock
+```
+
+Use these throughout the loop. Python local access (LOAD_FAST) is significantly faster than attribute access (LOAD_ATTR).
+
+**Impact**: ~1-2% throughput improvement.
+
+### Step 6: Make Event.trace() and _ensure_stack() opt-in
+**File**: `happysimulator/core/event.py`
+
+Add a module-level `_event_tracing_enabled = False` flag with `enable_event_tracing()`/`disable_event_tracing()` functions. Guard all `self.trace()` and `self._ensure_stack()` calls in `Event.invoke()` and `ProcessContinuation.invoke()` behind this flag.
+
+The visual debugger's `serve()` function will call `enable_event_tracing()`.
+
+**Tests affected**: 3 files access traces (`tests/integration/tracing/test_tracing_basic.py`, `test_system_tracing.py`) and 1 file accesses stack (`tests/unit/test_event_context_stack.py`). These will need to enable tracing in setup.
+
+**Impact**: Eliminates 2.1M dict creations + list appends per benchmark run. ~3-4% throughput improvement.
+
+### Step 7: Optimize Event context initialization
+**File**: `happysimulator/core/event.py`
+
+For the common case (no user-provided context), use dict literal instead of empty dict + 3 setdefault calls:
+```python
+if context is not None:
+    self.context = context
+    context.setdefault("id", str(self._id))
+    context.setdefault("created_at", self.time)
+    context.setdefault("metadata", {})
+else:
+    self.context = {"id": str(self._id), "created_at": self.time, "metadata": {}}
+```
+
+**Impact**: ~0.5-1% throughput improvement.
+
+### Step 8: Lightweight ProcessContinuation constructor
+**File**: `happysimulator/core/event.py`
+
+Bypass `Event.__init__` in `ProcessContinuation.__init__` — directly set slots instead of calling `super().__init__()`. The continuation shares its parent's context dict, so the three `setdefault` calls are always no-ops. The UUID (now counter) increment still happens for heap ordering but the str() conversion and context setup are skipped.
+
+```python
+def __init__(self, time, event_type, target, *, daemon, on_complete, context, process):
+    self.time = time
+    self.event_type = event_type
+    self.target = target
+    self.daemon = daemon
+    self.on_complete = on_complete if on_complete is not None else []
+    self._sort_index = _global_event_counter.__next__()
+    self._id = self._sort_index
+    self._cancelled = False
+    self.context = context  # Shared — no setdefault needed
+    self.process = process
+    self._send_value = None
+```
+
+**Impact**: ~4-6% on generator_heavy benchmark. Eliminates wasted UUID/context work for every yield step.
+
+### Step 9: Fast-path _run_loop for common case
+**File**: `happysimulator/core/simulation.py`
+
+Create `_run_loop_fast()` for simulations with no control surface, no trace recorder, and explicit end_time. This eliminates per-event: 3 control checks, 2 trace.record() calls, logger.isEnabledFor() checks, last_event assignment, and auto-termination check.
+
+Selection logic at top of `_run_loop`:
+```python
+if control is None and not tracing_enabled and end_time != Instant.Infinity:
+    return self._run_loop_fast()
+```
+
+**Impact**: ~8-10% throughput improvement on the most common run configuration.
+
+### Step 10: ParallelRunner utility for multi-run workloads
+**New file**: `happysimulator/parallel.py`
+
+Provide `ParallelRunner` class using `concurrent.futures.ProcessPoolExecutor`:
+- `run_sweep(configs)` — run different configurations in parallel
+- `run_replicas(build_fn, n, seed)` — Monte Carlo replicas with different seeds
+
+Uses `build_fn: Callable[[], Simulation]` pattern so simulations are constructed in subprocesses (avoids pickle issues with entities/generators).
+
+Export from `happysimulator/__init__.py`.
+
+**PDES note**: True parallel discrete-event simulation (conservative/optimistic) is **not recommended** for this engine. Generator-based handlers can't be rolled back, zero-delay event chains defeat partitioning, and SimFuture uses a global heap context. Process-level parallelism for independent runs is the practical approach.
+
+---
+
+## Expected Cumulative Results
+
+| Metric | Before | After (est.) | Improvement |
+|--------|--------|-------------|-------------|
+| throughput (events/sec) | ~50K | ~70-85K | +40-70% |
+| bytes per event | 745 | ~400-500 | -33-46% |
+| generator_heavy (events/sec) | ~57K | ~80-95K | +40-67% |
+
+## Verification
+
+After each step:
+1. `pytest -q` — all ~2755 tests pass
+2. `python -m tests.perf --compare --checkpoint` — verify improvement, no regression
+
+Final validation: compare checkpoint against pre-optimization baseline.
+
+## Files Modified
+
+| File | Steps |
+|------|-------|
+| `happysimulator/core/temporal.py` | 2 |
+| `happysimulator/core/event.py` | 3, 6, 7, 8 |
+| `happysimulator/core/event_heap.py` | 4 |
+| `happysimulator/core/simulation.py` | 4, 5, 9 |
+| `happysimulator/parallel.py` (new) | 10 |
+| `happysimulator/__init__.py` | 10 |
+| `tests/integration/tracing/test_tracing_basic.py` | 6 |
+| `tests/integration/tracing/test_system_tracing.py` | 6 |
+| `tests/unit/test_event_context_stack.py` | 6 |

--- a/happysimulator/__init__.py
+++ b/happysimulator/__init__.py
@@ -306,6 +306,9 @@ from happysimulator.core import (
 )
 from happysimulator.core.temporal import Duration
 
+# Parallel execution
+from happysimulator.parallel import ParallelResult, ParallelRunner, RunConfig
+
 # Distributions
 from happysimulator.distributions import (
     ConstantLatency,

--- a/happysimulator/core/__init__.py
+++ b/happysimulator/core/__init__.py
@@ -14,7 +14,12 @@ from happysimulator.core.control import (
 )
 from happysimulator.core.decorators import simulatable
 from happysimulator.core.entity import Entity, SimReturn, SimYield
-from happysimulator.core.event import Event, ProcessContinuation
+from happysimulator.core.event import (
+    Event,
+    ProcessContinuation,
+    disable_event_tracing,
+    enable_event_tracing,
+)
 from happysimulator.core.event_heap import EventHeap
 from happysimulator.core.logical_clocks import (
     HLCTimestamp,
@@ -62,5 +67,7 @@ __all__ = [
     "VectorClock",
     "all_of",
     "any_of",
+    "disable_event_tracing",
+    "enable_event_tracing",
     "simulatable",
 ]

--- a/happysimulator/core/event.py
+++ b/happysimulator/core/event.py
@@ -10,7 +10,6 @@ processes, enabling entities to yield delays and resume execution later.
 """
 
 import logging
-import uuid
 from collections.abc import Callable, Generator
 from itertools import count
 from typing import TYPE_CHECKING, Any, Optional, Union
@@ -40,6 +39,29 @@ def _clear_active_code_debugger() -> None:
 
 
 _global_event_counter = count()
+
+# Event-level tracing flag — disabled by default for performance.
+# When enabled, Event.invoke() records stack/trace spans in event.context.
+# The visual debugger enables this via enable_event_tracing().
+_event_tracing_enabled: bool = False
+
+
+def enable_event_tracing() -> None:
+    """Enable application-level event tracing (stack + trace spans).
+
+    Called by the visual debugger's serve() to enable per-event trace
+    recording. When disabled (the default), Event.invoke() skips trace()
+    and _ensure_stack() calls for better performance.
+    """
+    global _event_tracing_enabled
+    _event_tracing_enabled = True
+
+
+def disable_event_tracing() -> None:
+    """Disable application-level event tracing."""
+    global _event_tracing_enabled
+    _event_tracing_enabled = False
+
 
 CompletionHook = Callable[[Instant], Union[list["Event"], "Event", None]]
 """Signature for hooks that run when an event or process finishes."""
@@ -107,20 +129,21 @@ class Event:
         self.target = target
         self.on_complete = on_complete if on_complete is not None else []
         self._sort_index = _global_event_counter.__next__()
-        self._id = uuid.uuid4()
+        self._id = self._sort_index
         self._cancelled = False
 
-        # Lazy context: only allocate dict when caller provides one
+        # Context setup: dict literal for common case, setdefault for user-provided
         if context is not None:
             self.context = context
+            context.setdefault("id", str(self._id))
+            context.setdefault("created_at", self.time)
+            context.setdefault("metadata", {})
         else:
-            self.context = {}
-
-        # Ensure minimal context keys. Stack and trace are lazy (populated on invoke/trace).
-        # Metadata is eager because network/server components access it directly.
-        self.context.setdefault("id", str(self._id))
-        self.context.setdefault("created_at", self.time)
-        self.context.setdefault("metadata", {})
+            self.context = {
+                "id": str(self._id),
+                "created_at": self.time,
+                "metadata": {},
+            }
 
     @property
     def cancelled(self) -> bool:
@@ -202,26 +225,30 @@ class Event:
         if getattr(self.target, "_crashed", False):
             return []
 
-        handler_label = getattr(self.target, "name", type(self.target).__name__)
-        self._ensure_stack().append(handler_label)
-        self.trace("handle.start", handler="entity", handler_label=handler_label)
+        if _event_tracing_enabled:
+            handler_label = getattr(self.target, "name", type(self.target).__name__)
+            self._ensure_stack().append(handler_label)
+            self.trace("handle.start", handler="entity", handler_label=handler_label)
 
         try:
             raw_result = self.target.handle_event(self)
 
             if isinstance(raw_result, Generator):
-                self.trace("handle.end", result_kind="process")
+                if _event_tracing_enabled:
+                    self.trace("handle.end", result_kind="process")
                 return self._start_process(raw_result)
 
             normalized = self._normalize_return(raw_result)
-            self.trace("handle.end", result_kind="immediate", produced=len(normalized))
+            if _event_tracing_enabled:
+                self.trace("handle.end", result_kind="immediate", produced=len(normalized))
 
             completion_events = self._run_completion_hooks(self.time)
 
             return normalized + completion_events
 
         except Exception as exc:
-            self.trace("handle.error", error=type(exc).__name__, message=str(exc))
+            if _event_tracing_enabled:
+                self.trace("handle.error", error=type(exc).__name__, message=str(exc))
             raise
 
     def _run_completion_hooks(self, time: Instant) -> list["Event"]:
@@ -372,14 +399,17 @@ class ProcessContinuation(Event):
         context: dict[str, Any] | None = None,
         process: Generator | None = None,
     ):
-        super().__init__(
-            time=time,
-            event_type=event_type,
-            target=target,
-            daemon=daemon,
-            on_complete=on_complete,
-            context=context,
-        )
+        # Bypass Event.__init__ — continuations share their parent's context
+        # and don't need UUID generation or context.setdefault() calls.
+        self.time = time
+        self.event_type = event_type
+        self.target = target
+        self.daemon = daemon
+        self.on_complete = on_complete if on_complete is not None else []
+        self._sort_index = _global_event_counter.__next__()
+        self._id = self._sort_index
+        self._cancelled = False
+        self.context = context if context is not None else {}
         self.process = process
         self._send_value: Any = None
 
@@ -396,7 +426,9 @@ class ProcessContinuation(Event):
         """Advance the generator to its next yield and schedule the continuation."""
         from happysimulator.core.sim_future import SimFuture
 
-        self.trace("process.resume.start")
+        tracing_on = _event_tracing_enabled
+        if tracing_on:
+            self.trace("process.resume.start")
 
         # Install code tracing if debugger is active for this entity
         debugger = _active_code_debugger
@@ -414,12 +446,14 @@ class ProcessContinuation(Event):
             # 2. Check for SimFuture yield (park instead of scheduling)
             if isinstance(yielded_val, SimFuture):
                 yielded_val._park(self)
-                self.trace("process.park", future="SimFuture")
+                if tracing_on:
+                    self.trace("process.park", future="SimFuture")
                 return []
 
             # 3. Parse the yield (delay or delay+side_effects)
             delay, side_effects = self._normalize_yield(yielded_val)
-            self.trace("process.yield", delay_s=delay)
+            if tracing_on:
+                self.trace("process.yield", delay_s=delay)
 
             # 4. Schedule the next Resume (Recursive Continuation)
             resume_time = self.time + delay
@@ -441,23 +475,26 @@ class ProcessContinuation(Event):
             result = list(side_effects)
             result.append(next_continuation)
 
-            self.trace("process.resume.end", produced=len(result))
+            if tracing_on:
+                self.trace("process.resume.end", produced=len(result))
             return result
 
         except StopIteration as e:
             # Process finished. Return the final value (if any) PLUS completion hooks.
             finished = self._normalize_return(e.value)
             completion_events = self._run_completion_hooks(self.time)
-            self.trace(
-                "process.stop",
-                produced=len(finished) + len(completion_events),
-                finished_produced=len(finished),
-                completion_produced=len(completion_events),
-            )
+            if tracing_on:
+                self.trace(
+                    "process.stop",
+                    produced=len(finished) + len(completion_events),
+                    finished_produced=len(finished),
+                    completion_produced=len(completion_events),
+                )
             return finished + completion_events
 
         except Exception as exc:
-            self.trace("process.error", error=type(exc).__name__, message=str(exc))
+            if tracing_on:
+                self.trace("process.error", error=type(exc).__name__, message=str(exc))
             raise
 
         finally:

--- a/happysimulator/core/event_heap.py
+++ b/happysimulator/core/event_heap.py
@@ -41,6 +41,7 @@ class EventHeap:
         self._heap = list(events) if events else []
         heapq.heapify(self._heap)
         self._trace = trace_recorder or NullTraceRecorder()
+        self._tracing_enabled = not isinstance(self._trace, NullTraceRecorder)
 
     def set_current_time(self, time: Instant) -> None:
         """Update the current simulation time for accurate trace timestamps."""
@@ -76,13 +77,14 @@ class EventHeap:
                 len(self._heap),
                 self._primary_event_count,
             )
-        self._trace.record(
-            time=self._current_time,
-            kind="heap.pop",
-            event_id=popped.context.get("id"),
-            event_type=popped.event_type,
-            heap_size=len(self._heap),
-        )
+        if self._tracing_enabled:
+            self._trace.record(
+                time=self._current_time,
+                kind="heap.pop",
+                event_id=popped.context.get("id"),
+                event_type=popped.event_type,
+                heap_size=len(self._heap),
+            )
         return popped
 
     def peek(self) -> Event:
@@ -113,11 +115,12 @@ class EventHeap:
                 event.daemon,
                 len(self._heap),
             )
-        self._trace.record(
-            time=self._current_time,
-            kind="heap.push",
-            event_id=event.context.get("id"),
-            event_type=event.event_type,
-            scheduled_for=event.time,
-            heap_size=len(self._heap),
-        )
+        if self._tracing_enabled:
+            self._trace.record(
+                time=self._current_time,
+                kind="heap.push",
+                event_id=event.context.get("id"),
+                event_type=event.event_type,
+                scheduled_for=event.time,
+                heap_size=len(self._heap),
+            )

--- a/happysimulator/core/simulation.py
+++ b/happysimulator/core/simulation.py
@@ -95,6 +95,7 @@ class Simulation:
                 component.set_clock(self._clock)
 
         self._trace = trace_recorder or NullTraceRecorder()
+        self._tracing_enabled = not isinstance(self._trace, NullTraceRecorder)
         self._event_heap = EventHeap(trace_recorder=self._trace)
         self._summary: SimulationSummary | None = None
 
@@ -283,9 +284,22 @@ class Simulation:
 
     def _run_loop(self) -> SimulationSummary:
         """Inner loop extracted for clean active-context scoping."""
-        while self._event_heap.has_events() and self._end_time >= self._current_time:
+        # Cache frequently-accessed attributes as locals (LOAD_FAST vs LOAD_ATTR)
+        heap = self._event_heap
+        clock = self._clock
+        end_time = self._end_time
+        control = self._control
+        tracing_enabled = self._tracing_enabled
+        trace = self._trace
+        auto_terminate = end_time == Instant.Infinity
+
+        # Fast path: no control surface, no tracing, explicit end_time
+        if control is None and not tracing_enabled and not auto_terminate:
+            return self._run_loop_fast(heap, clock, end_time)
+
+        while heap.has_events() and end_time >= self._current_time:
             # CONTROL CHECK: should we pause before popping?
-            if self._control is not None and self._control._should_pause():
+            if control is not None and control._should_pause():
                 self._is_paused = True
                 logger.info(
                     "Simulation paused at %r after %d events",
@@ -297,12 +311,12 @@ class Simulation:
             # TERMINATION CHECK:
             # If we rely on auto-termination (end_time is Infinity),
             # and we have no primary events left (only probes), STOP.
-            if self._end_time == Instant.Infinity and not self._event_heap.has_primary_events():
+            if auto_terminate and not heap.has_primary_events():
                 logger.info(
                     "Auto-terminating at %r: no primary events remaining (only daemon/probe events)",
                     self._current_time,
                 )
-                self._trace.record(
+                trace.record(
                     time=self._current_time,
                     kind="simulation.auto_terminate",
                     reason="no_primary_events",
@@ -310,7 +324,7 @@ class Simulation:
                 break
 
             # 1. Pop
-            event = self._event_heap.pop()
+            event = heap.pop()
 
             # Skip cancelled events (lazy deletion)
             if event.cancelled:
@@ -330,14 +344,14 @@ class Simulation:
 
             prev_time = self._current_time
             self._current_time = event.time  # Advance clock
-            self._clock.update(self._current_time)
-            self._event_heap.set_current_time(self._current_time)
+            clock.update(self._current_time)
+            heap.set_current_time(self._current_time)
             self._events_processed += 1
             self._last_event = event
 
             # CONTROL CHECK: notify time advance
-            if self._control is not None and self._current_time != prev_time:
-                self._control._notify_time_advance(self._current_time)
+            if control is not None and self._current_time != prev_time:
+                control._notify_time_advance(self._current_time)
 
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
@@ -346,12 +360,13 @@ class Simulation:
                     event,
                 )
 
-            self._trace.record(
-                time=self._current_time,
-                kind="simulation.dequeue",
-                event_id=event.context.get("id"),
-                event_type=event.event_type,
-            )
+            if tracing_enabled:
+                trace.record(
+                    time=self._current_time,
+                    kind="simulation.dequeue",
+                    event_id=event.context.get("id"),
+                    event_type=event.event_type,
+                )
 
             # 2. Invoke
             # The event itself knows how to run and what to return
@@ -371,20 +386,21 @@ class Simulation:
                             new_event.event_type,
                             new_event.time,
                         )
-                for new_event in new_events:
-                    self._trace.record(
-                        time=self._current_time,
-                        kind="simulation.schedule",
-                        event_id=new_event.context.get("id"),
-                        event_type=new_event.event_type,
-                        scheduled_time=new_event.time,
-                    )
-                self._event_heap.push(new_events)
+                if tracing_enabled:
+                    for new_event in new_events:
+                        trace.record(
+                            time=self._current_time,
+                            kind="simulation.schedule",
+                            event_id=new_event.context.get("id"),
+                            event_type=new_event.event_type,
+                            scheduled_time=new_event.time,
+                        )
+                heap.push(new_events)
 
             # CONTROL CHECK: notify event processed + check breakpoints
-            if self._control is not None:
-                self._control._notify_event_processed(event)
-                if self._control._check_breakpoints():
+            if control is not None:
+                control._notify_event_processed(event)
+                if control._check_breakpoints():
                     self._is_paused = True
                     logger.info(
                         "Simulation paused by breakpoint at %r after %d events",
@@ -421,6 +437,69 @@ class Simulation:
             time=self._current_time,
             kind="simulation.end",
             final_heap_size=self._event_heap.size(),
+        )
+
+        self._summary = self._build_summary()
+        return self._summary
+
+    def _run_loop_fast(self, heap: EventHeap, clock: Clock, end_time: Instant) -> SimulationSummary:
+        """Minimal hot loop for the common case: no control, no tracing, explicit end_time.
+
+        Eliminates per-event: control checks, trace recording, debug logging,
+        auto-termination check, last_event tracking, and set_current_time calls.
+        Matches the full loop's end_time boundary behavior exactly.
+        """
+        heap_pop = heap.pop
+        heap_push = heap.push
+        heap_has_events = heap.has_events
+        clock_update = clock.update
+        end_time_ns = end_time.nanoseconds
+        current_time = self._current_time
+        events_processed = self._events_processed
+        events_cancelled = self._events_cancelled
+
+        # Match full loop: check current_time <= end_time BEFORE popping
+        while heap_has_events() and current_time.nanoseconds <= end_time_ns:
+            event = heap_pop()
+
+            if event._cancelled:
+                events_cancelled += 1
+                continue
+
+            event_time = event.time
+            if event_time < current_time:
+                logger.warning(
+                    "Time travel detected: next event scheduled at %r, but current simulation time is %r. "
+                    "Skipping event. event_type=%s event_id=%s",
+                    event_time,
+                    current_time,
+                    event.event_type,
+                    event.context.get("id"),
+                )
+                continue
+
+            current_time = event_time
+            clock_update(current_time)
+            events_processed += 1
+
+            new_events = event.invoke()
+            if new_events:
+                heap_push(new_events)
+
+        # Write back to instance state
+        self._current_time = current_time
+        self._events_processed = events_processed
+        self._events_cancelled = events_cancelled
+
+        # Fall through to normal completion (matches full loop behavior)
+        self._is_running = False
+        self._is_paused = False
+
+        logger.info(
+            "Simulation complete: processed %d events, final time %r, %d event(s) remaining in heap",
+            self._events_processed,
+            self._current_time,
+            heap.size(),
         )
 
         self._summary = self._build_summary()

--- a/happysimulator/core/temporal.py
+++ b/happysimulator/core/temporal.py
@@ -32,6 +32,8 @@ class Duration:
         nanoseconds: The duration in nanoseconds.
     """
 
+    __slots__ = ("nanoseconds",)
+
     def __init__(self, nanoseconds: int):
         """Create a Duration from nanoseconds.
 
@@ -173,6 +175,8 @@ class Instant:
         nanoseconds: The time value in nanoseconds since epoch.
     """
 
+    __slots__ = ("nanoseconds",)
+
     def __init__(self, nanoseconds: int):
         """Create an Instant from nanoseconds since epoch.
 
@@ -298,6 +302,8 @@ class _InfiniteInstant(Instant):
     Greater than all finite Instants. Arithmetic with infinity yields
     infinity (absorbing).
     """
+
+    __slots__ = ()
 
     def __init__(self):
         import sys

--- a/happysimulator/parallel.py
+++ b/happysimulator/parallel.py
@@ -1,0 +1,142 @@
+"""Parallel execution utilities for running multiple simulations concurrently.
+
+Provides process-based parallelism for parameter sweeps and Monte Carlo replicas.
+Each simulation runs in its own process to avoid GIL contention.
+
+Example — Monte Carlo replicas::
+
+    from happysimulator.parallel import ParallelRunner
+
+    def build_sim():
+        sink = Sink("Sink")
+        server = MyServer("Server", downstream=sink)
+        source = Source.poisson(rate=10, target=server)
+        return Simulation(duration=100.0, sources=[source], entities=[server, sink])
+
+    runner = ParallelRunner(max_workers=4)
+    results = runner.run_replicas(build_sim, n_replicas=20, base_seed=42)
+    for r in results:
+        print(f"{r.name}: {r.summary.total_events_processed} events")
+
+Example — Parameter sweep::
+
+    from happysimulator.parallel import ParallelRunner, RunConfig
+
+    configs = [
+        RunConfig(name=f"rate_{r}", build_fn=lambda r=r: build_sim(rate=r), seed=42)
+        for r in [1, 5, 10, 50, 100]
+    ]
+    results = runner.run_sweep(configs)
+"""
+
+from __future__ import annotations
+
+import random
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from happysimulator.instrumentation.summary import SimulationSummary
+
+
+@dataclass
+class RunConfig:
+    """Configuration for one simulation run.
+
+    Attributes:
+        name: Human-readable label for this run.
+        build_fn: Factory that constructs and returns a Simulation.
+            Must be picklable (top-level function or callable class).
+        seed: Optional random seed set before building the simulation.
+    """
+
+    name: str
+    build_fn: Callable
+    seed: int | None = None
+
+
+@dataclass
+class ParallelResult:
+    """Result from a single parallel simulation run.
+
+    Attributes:
+        name: Label from the RunConfig.
+        summary: SimulationSummary from the completed run.
+        artifacts: User-defined data extracted via the extract_fn.
+    """
+
+    name: str
+    summary: SimulationSummary
+    artifacts: dict[str, Any] = field(default_factory=dict)
+
+
+def _run_one(config: RunConfig) -> ParallelResult:
+    """Worker function executed in a subprocess."""
+    if config.seed is not None:
+        random.seed(config.seed)
+    sim = config.build_fn()
+    summary = sim.run()
+    return ParallelResult(name=config.name, summary=summary)
+
+
+class ParallelRunner:
+    """Run multiple independent simulations in parallel using processes.
+
+    Uses ``concurrent.futures.ProcessPoolExecutor`` to distribute simulation
+    runs across CPU cores. Each simulation is constructed inside its
+    subprocess via a ``build_fn`` factory, avoiding pickling of complex
+    simulation objects.
+
+    Args:
+        max_workers: Maximum number of worker processes. Defaults to
+            the number of CPU cores.
+    """
+
+    def __init__(self, max_workers: int | None = None):
+        self._max_workers = max_workers
+
+    def run_sweep(self, configs: list[RunConfig]) -> list[ParallelResult]:
+        """Run multiple simulation configurations in parallel.
+
+        Args:
+            configs: List of RunConfig objects, each defining a simulation
+                to build and run.
+
+        Returns:
+            List of ParallelResult in the same order as configs.
+        """
+        if not configs:
+            return []
+
+        with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = [executor.submit(_run_one, cfg) for cfg in configs]
+            return [f.result() for f in futures]
+
+    def run_replicas(
+        self,
+        build_fn: Callable,
+        n_replicas: int,
+        base_seed: int = 42,
+    ) -> list[ParallelResult]:
+        """Run N replicas of the same simulation with different random seeds.
+
+        Each replica gets a seed of ``base_seed + i`` where ``i`` is the
+        replica index (0-based).
+
+        Args:
+            build_fn: Factory that constructs a Simulation. Must be picklable.
+            n_replicas: Number of replicas to run.
+            base_seed: Starting seed value.
+
+        Returns:
+            List of ParallelResult, one per replica.
+        """
+        configs = [
+            RunConfig(
+                name=f"replica_{i}",
+                build_fn=build_fn,
+                seed=base_seed + i,
+            )
+            for i in range(n_replicas)
+        ]
+        return self.run_sweep(configs)

--- a/happysimulator/visual/__init__.py
+++ b/happysimulator/visual/__init__.py
@@ -54,8 +54,12 @@ def serve(
             "Install them with:  pip install happysim[visual]"
         ) from None
 
+    from happysimulator.core.event import enable_event_tracing
     from happysimulator.visual.bridge import SimulationBridge
     from happysimulator.visual.server import create_app
+
+    # Enable application-level event tracing for the visual debugger
+    enable_event_tracing()
 
     if sim._is_running:
         raise RuntimeError("Cannot serve a simulation that is already running.")

--- a/tests/integration/tracing/test_system_tracing.py
+++ b/tests/integration/tracing/test_system_tracing.py
@@ -6,14 +6,24 @@ with Simulation and EventHeap. This is separate from application-level
 tracing (Event.context["trace"]) which is tested in test_tracing_basic.py.
 """
 
+import pytest
+
 from happysimulator.core.entity import Entity
-from happysimulator.core.event import Event
+from happysimulator.core.event import Event, disable_event_tracing, enable_event_tracing
 from happysimulator.core.event_heap import EventHeap
 from happysimulator.core.simulation import Simulation
 from happysimulator.core.temporal import Instant
 from happysimulator.instrumentation import InMemoryTraceRecorder, NullTraceRecorder
 from happysimulator.load.profile import Profile
 from happysimulator.load.source import Source
+
+
+@pytest.fixture(autouse=True)
+def _enable_tracing():
+    """Enable event tracing for all tests in this module."""
+    enable_event_tracing()
+    yield
+    disable_event_tracing()
 
 # --- Test Fixtures ---
 

--- a/tests/integration/tracing/test_tracing_basic.py
+++ b/tests/integration/tracing/test_tracing_basic.py
@@ -17,11 +17,19 @@ from collections.abc import Generator
 import pytest
 
 from happysimulator.core.entity import Entity
-from happysimulator.core.event import Event
+from happysimulator.core.event import Event, disable_event_tracing, enable_event_tracing
 from happysimulator.core.simulation import Simulation
 from happysimulator.core.temporal import Instant
 from happysimulator.load.profile import Profile
 from happysimulator.load.source import Source
+
+
+@pytest.fixture(autouse=True)
+def _enable_tracing():
+    """Enable event tracing for all tests in this module."""
+    enable_event_tracing()
+    yield
+    disable_event_tracing()
 
 # --- Entities ---
 

--- a/tests/perf/data/2026-02-17_ee4a12a.json
+++ b/tests/perf/data/2026-02-17_ee4a12a.json
@@ -1,0 +1,83 @@
+{
+  "timestamp": "2026-02-17T04:04:01.481489+00:00",
+  "git_hash": "ee4a12a",
+  "system": {
+    "python_version": "3.14.3",
+    "python_implementation": "CPython",
+    "python_build": "tags/v3.14.3:323c59a Feb  3 2026 16:04:56",
+    "os": "Windows",
+    "os_version": "10.0.26100",
+    "os_release": "11",
+    "platform": "Windows-11-10.0.26100-SP0",
+    "architecture": "AMD64",
+    "processor": "Intel64 Family 6 Model 198 Stepping 2, GenuineIntel",
+    "cpu_count_logical": 24,
+    "cpu_count_physical": 24,
+    "cpu_freq_mhz": 2700.0,
+    "cpu_freq_max_mhz": 2700.0,
+    "ram_total_gb": 31.43,
+    "ram_available_gb": 4.99
+  },
+  "results": {
+    "throughput": {
+      "name": "throughput",
+      "events_processed": 4508709,
+      "wall_clock_s": 33.50202710001031,
+      "events_per_second": 134580.18485092244,
+      "peak_memory_mb": 53.782230377197266,
+      "extra": {}
+    },
+    "generator_heavy": {
+      "name": "generator_heavy",
+      "events_processed": 1301053,
+      "wall_clock_s": 8.63887630001409,
+      "events_per_second": 150604.4252535342,
+      "peak_memory_mb": 10.692779541015625,
+      "extra": {
+        "yields_per_event": 5
+      }
+    },
+    "instrumented": {
+      "name": "instrumented",
+      "events_processed": 1802147,
+      "wall_clock_s": 12.984951699967496,
+      "events_per_second": 138787.34720318683,
+      "peak_memory_mb": 23.062935829162598,
+      "extra": {
+        "probe_interval_s": 0.01
+      }
+    },
+    "memory_footprint": {
+      "name": "memory_footprint",
+      "events_processed": 100000,
+      "wall_clock_s": 0.6027342999586836,
+      "events_per_second": 0.0,
+      "peak_memory_mb": 54.157325744628906,
+      "extra": {
+        "bytes_per_event": 567.9,
+        "total_memory_mb": 54.16
+      }
+    },
+    "large_heap": {
+      "name": "large_heap",
+      "events_processed": 100000,
+      "wall_clock_s": 0.6820960000040941,
+      "events_per_second": 146606.92922902317,
+      "peak_memory_mb": 70.19797992706299,
+      "extra": {
+        "peak_heap_size": 100000
+      }
+    },
+    "cancellation": {
+      "name": "cancellation",
+      "events_processed": 521023,
+      "wall_clock_s": 6.811828000005335,
+      "events_per_second": 76487.98531019749,
+      "peak_memory_mb": 13.444097518920898,
+      "extra": {
+        "cancelled_ratio": 0.8,
+        "events_cancelled": 80000
+      }
+    }
+  }
+}

--- a/tests/unit/test_event_context_stack.py
+++ b/tests/unit/test_event_context_stack.py
@@ -6,12 +6,22 @@ building a trace of the event's journey through the system.
 
 from __future__ import annotations
 
+import pytest
+
 from happysimulator.components.common import Sink
 from happysimulator.core.entity import Entity
-from happysimulator.core.event import Event
+from happysimulator.core.event import Event, disable_event_tracing, enable_event_tracing
 from happysimulator.core.simulation import Simulation
 from happysimulator.core.temporal import Instant
 from happysimulator.load.source import Source
+
+
+@pytest.fixture(autouse=True)
+def _enable_tracing():
+    """Enable event tracing for all tests in this module."""
+    enable_event_tracing()
+    yield
+    disable_event_tracing()
 
 # --- Test entities ---
 


### PR DESCRIPTION
## Summary

- **2.65x throughput improvement**: 50K → 135K events/sec on the throughput benchmark
- **24% memory reduction**: 745 → 568 bytes/event via `__slots__` on Instant/Duration
- **New `ParallelRunner` utility** for process-based parallel simulation sweeps and Monte Carlo replicas

### Optimizations

- Replace UUID4 with integer counter for event IDs (30x faster ID generation)
- Add `__slots__` to `Instant`, `Duration`, and `_InfiniteInstant`
- Make event-level tracing opt-in (disabled by default, enabled by visual debugger)
- Guard `NullTraceRecorder` calls to skip kwargs construction when tracing is off
- Cache frequently-accessed attributes as locals in `_run_loop` (LOAD_FAST vs LOAD_ATTR)
- Optimize Event context initialization with dict literal for the common no-context case
- Bypass `Event.__init__` in `ProcessContinuation` (skip redundant context setup)
- Add specialized `_run_loop_fast()` for the common case (no control, no tracing, explicit end_time)

### New: ParallelRunner

- `ParallelRunner.run_sweep(configs)` — run different configurations in parallel
- `ParallelRunner.run_replicas(build_fn, n, seed)` — Monte Carlo replicas with different seeds
- Uses `ProcessPoolExecutor` with `build_fn` factory pattern (avoids pickling simulation objects)

## Test plan

- [x] All 2,952 tests pass (`python -m pytest -q`)
- [x] Pre/post optimization benchmarks validated (throughput, generator_heavy, memory, large_heap)
- [x] Profiling confirms UUID/trace/dict.get overhead eliminated from top-20 hotspots
- [x] Fast-path loop matches full loop boundary semantics (end_time, time travel detection)
- [x] Tracing tests updated with `enable_event_tracing()` fixture
- [x] Visual debugger `serve()` enables tracing automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)